### PR TITLE
allow in fastapi to return related models with only pk populated

### DIFF
--- a/ormar/__init__.py
+++ b/ormar/__init__.py
@@ -30,7 +30,7 @@ class UndefinedType:  # pragma no cover
 
 Undefined = UndefinedType()
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 __all__ = [
     "Integer",
     "BigInteger",

--- a/tests/test_more_reallife_fastapi.py
+++ b/tests/test_more_reallife_fastapi.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import List, Optional
 
 import databases
@@ -128,6 +129,11 @@ def test_all_endpoints():
         response = client.get("/items/raw/")
         items = [Item(**item) for item in response.json()]
         assert items[0].name == "New name"
+        assert items[0].category.name is None
+
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(items[0].category.load())
+        assert items[0].category.name is not None
 
         response = client.get(f"/items/{item.pk}")
         new_item = Item(**response.json())

--- a/tests/test_more_reallife_fastapi.py
+++ b/tests/test_more_reallife_fastapi.py
@@ -64,6 +64,12 @@ async def get_items():
     return items
 
 
+@app.get("/items/raw/", response_model=List[Item])
+async def get_raw_items():
+    items = await Item.objects.all()
+    return items
+
+
 @app.post("/items/", response_model=Item)
 async def create_item(item: Item):
     await item.save()
@@ -74,6 +80,12 @@ async def create_item(item: Item):
 async def create_category(category: Category):
     await category.save()
     return category
+
+
+@app.get("/items/{item_id}")
+async def get_item(item_id: int):
+    item = await Item.objects.get(pk=item_id)
+    return item
 
 
 @app.put("/items/{item_id}")
@@ -112,6 +124,14 @@ def test_all_endpoints():
         response = client.get("/items/")
         items = [Item(**item) for item in response.json()]
         assert items[0].name == "New name"
+
+        response = client.get("/items/raw/")
+        items = [Item(**item) for item in response.json()]
+        assert items[0].name == "New name"
+
+        response = client.get(f"/items/{item.pk}")
+        new_item = Item(**response.json())
+        assert new_item == item
 
         response = client.delete(f"/items/{item.pk}")
         assert response.json().get("deleted_rows", "__UNDEFINED__") != "__UNDEFINED__"


### PR DESCRIPTION
Create a dynamic model with pk only and add it to allowed responses/ field types for foreign key to allow passing pk_only models through fastapi.