### PR TITLE
support updating models on the many side of the one-to-many relations.

### DIFF
--- a/ormar/models/modelproxy.py
+++ b/ormar/models/modelproxy.py
@@ -70,14 +70,15 @@ class ModelTableProxy:
                             f"model without pk set!"
                         )
                     model_dict[field] = pk_value
-                elif isinstance(field_value, list):
-                    targets = [target.get(target_pkname) for target in field_value]
-                    if targets:
-                        model_dict[field] = targets
+                elif field_value:  # nested dict
+                    if isinstance(field_value, list):
+                        model_dict[field] = [
+                            target.get(target_pkname) for target in field_value
+                        ]
                     else:
-                        model_dict.pop(field)
-                else:  # nested dict
-                    model_dict[field] = field_value.get(target_pkname)
+                        model_dict[field] = field_value.get(target_pkname)
+                else:
+                    model_dict.pop(field)
         return model_dict
 
     @classmethod

--- a/ormar/models/modelproxy.py
+++ b/ormar/models/modelproxy.py
@@ -78,7 +78,7 @@ class ModelTableProxy:
                     else:
                         model_dict[field] = field_value.get(target_pkname)
                 else:
-                    model_dict.pop(field)
+                    model_dict.pop(field, None)
         return model_dict
 
     @classmethod

--- a/ormar/models/modelproxy.py
+++ b/ormar/models/modelproxy.py
@@ -70,6 +70,12 @@ class ModelTableProxy:
                             f"model without pk set!"
                         )
                     model_dict[field] = pk_value
+                elif isinstance(field_value, list):
+                    targets = [target.get(target_pkname) for target in field_value]
+                    if targets:
+                        model_dict[field] = targets
+                    else:
+                        model_dict.pop(field)
                 elif field_value:  # nested dict
                     model_dict[field] = field_value.get(target_pkname)
                 else:

--- a/ormar/models/modelproxy.py
+++ b/ormar/models/modelproxy.py
@@ -76,10 +76,8 @@ class ModelTableProxy:
                         model_dict[field] = targets
                     else:
                         model_dict.pop(field)
-                elif field_value:  # nested dict
+                else:  # nested dict
                     model_dict[field] = field_value.get(target_pkname)
-                else:
-                    model_dict.pop(field, None)
         return model_dict
 
     @classmethod
@@ -237,7 +235,9 @@ class ModelTableProxy:
 
     @staticmethod
     def _populate_pk_column(
-        model: Type["Model"], columns: List[str], use_alias: bool = False,
+        model: Type["Model"],
+        columns: List[str],
+        use_alias: bool = False,
     ) -> List[str]:
         pk_alias = (
             model.get_column_alias(model.Meta.pkname)

--- a/tests/test_foreign_keys.py
+++ b/tests/test_foreign_keys.py
@@ -376,3 +376,16 @@ async def test_wrong_model_passed_as_fk():
             with pytest.raises(RelationshipInstanceError):
                 org = await Organisation.objects.create(ident="ACME Ltd")
                 await Track.objects.create(album=org, title="Test1", position=1)
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_model_with_children():
+    async with database:
+        async with database.transaction(force_rollback=True):
+            album = await Album.objects.create(name="Test")
+            track = await Track.objects.create(album=album, title="Test1", position=1)
+            album.name = "Test2"
+            await Album.objects.bulk_update([album], columns=["name"])
+
+            updated_album = await Album.objects.get(id=album.id)
+            assert updated_album.name == "Test2"


### PR DESCRIPTION
Hi.
I ran into some issues updating models on the "many" side of one-to-many relations.
E.g., Album with many tracks.
As seen in the new test:
`await Album.objects.bulk_update([album], columns=["name"])`

This PR attempts to fix those issues :)

However, it might be that I am using the api wrong.
I don't know why the tracks are not updated as seen in the last test:
`assert len(updated_album.tracks) == 0`

I think this is related to https://github.com/collerek/ormar/issues/50