### PR TITLE
M2m fields

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,3 +1,13 @@
+# 0.9.3
+
+## Fixes
+* Fix `JSON` field being double escaped when setting value after initialization
+* Fix `JSON` field not respecting `nullable` field setting due to `pydantic` internals 
+* Fix `choices` verification for `JSON` field
+* Fix `choices` not being verified when setting the attribute after initialization
+* Fix `choices` not being verified during `update` call from `QuerySet`
+
+
 # 0.9.2
 
 ## Other

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,8 @@ nav:
             - api/models/helpers/pydantic.md
             - api/models/helpers/relations.md
             - api/models/helpers/sqlalchemy.md
+            - api/models/helpers/validation.md
+            - api/models/helpers/related-names-validation.md
         - Mixins:
             - Alias Mixin: api/models/mixins/alias-mixin.md
             - Excludable Mixin: api/models/mixins/excludable-mixin.md

--- a/ormar/__init__.py
+++ b/ormar/__init__.py
@@ -19,7 +19,8 @@ snakes, and ormar(e) in italian which means cabinet.
 And what's a better name for python ORM than snakes cabinet :)
 
 """
-from ormar.decorators import (
+from ormar.protocols import QuerySetProtocol, RelationProtocol  # noqa: I100
+from ormar.decorators import (  # noqa: I100
     post_delete,
     post_save,
     post_update,
@@ -28,13 +29,13 @@ from ormar.decorators import (
     pre_update,
     property_field,
 )
-from ormar.protocols import QuerySetProtocol, RelationProtocol  # noqa: I100
 from ormar.exceptions import (  # noqa: I100
     ModelDefinitionError,
     MultipleMatches,
     NoMatch,
 )
-from ormar.fields import (  # noqa: I100
+from ormar.fields import (
+    BaseField,
     BigInteger,
     Boolean,
     Date,
@@ -42,15 +43,17 @@ from ormar.fields import (  # noqa: I100
     Decimal,
     Float,
     ForeignKey,
+    ForeignKeyField,
     Integer,
     JSON,
     ManyToMany,
+    ManyToManyField,
     String,
     Text,
     Time,
     UUID,
     UniqueColumns,
-)
+)  # noqa: I100
 from ormar.models import Model
 from ormar.models.metaclass import ModelMeta
 from ormar.queryset import QuerySet
@@ -65,7 +68,7 @@ class UndefinedType:  # pragma no cover
 
 Undefined = UndefinedType()
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 __all__ = [
     "Integer",
     "BigInteger",
@@ -100,4 +103,7 @@ __all__ = [
     "pre_save",
     "pre_update",
     "Signal",
+    "BaseField",
+    "ManyToManyField",
+    "ForeignKeyField",
 ]

--- a/ormar/fields/__init__.py
+++ b/ormar/fields/__init__.py
@@ -5,7 +5,7 @@ as well as relation Fields (ForeignKey, ManyToMany).
 Also a definition for custom CHAR based sqlalchemy UUID field
 """
 from ormar.fields.base import BaseField
-from ormar.fields.foreign_key import ForeignKey, UniqueColumns
+from ormar.fields.foreign_key import ForeignKey, ForeignKeyField, UniqueColumns
 from ormar.fields.many_to_many import ManyToMany, ManyToManyField
 from ormar.fields.model_fields import (
     BigInteger,
@@ -40,4 +40,5 @@ __all__ = [
     "ManyToManyField",
     "BaseField",
     "UniqueColumns",
+    "ForeignKeyField",
 ]

--- a/ormar/fields/foreign_key.py
+++ b/ormar/fields/foreign_key.py
@@ -222,7 +222,7 @@ class ForeignKeyField(BaseField):
 
     to: Type["Model"]
     name: str
-    related_name: str
+    related_name: str  # type: ignore
     virtual: bool
     ondelete: str
     onupdate: str

--- a/ormar/models/helpers/__init__.py
+++ b/ormar/models/helpers/__init__.py
@@ -1,5 +1,7 @@
 from ormar.models.helpers.models import (
+    check_required_meta_parameters,
     extract_annotations_and_default_vals,
+    meta_field_not_set,
     populate_default_options_values,
 )
 from ormar.models.helpers.pydantic import (
@@ -15,7 +17,9 @@ from ormar.models.helpers.relations import expand_reverse_relationships
 from ormar.models.helpers.sqlalchemy import (
     populate_meta_sqlalchemy_table_if_required,
     populate_meta_tablename_columns_and_pk,
+    sqlalchemy_columns_from_model_fields,
 )
+from ormar.models.helpers.validation import populate_choices_validators
 
 __all__ = [
     "expand_reverse_relationships",
@@ -28,4 +32,8 @@ __all__ = [
     "get_pydantic_field",
     "get_potential_fields",
     "get_pydantic_base_orm_config",
+    "check_required_meta_parameters",
+    "sqlalchemy_columns_from_model_fields",
+    "populate_choices_validators",
+    "meta_field_not_set",
 ]

--- a/ormar/models/helpers/pydantic.py
+++ b/ormar/models/helpers/pydantic.py
@@ -1,7 +1,7 @@
 import warnings
 from typing import Dict, Optional, TYPE_CHECKING, Tuple, Type
 
-from pydantic import BaseConfig
+import pydantic
 from pydantic.fields import ModelField
 from pydantic.utils import lenient_issubclass
 
@@ -132,7 +132,7 @@ def populate_pydantic_default_values(attrs: Dict) -> Tuple[Dict, Dict]:
     return attrs, model_fields
 
 
-def get_pydantic_base_orm_config() -> Type[BaseConfig]:
+def get_pydantic_base_orm_config() -> Type[pydantic.BaseConfig]:
     """
     Returns empty pydantic Config with orm_mode set to True.
 
@@ -140,7 +140,7 @@ def get_pydantic_base_orm_config() -> Type[BaseConfig]:
     :rtype: pydantic Config
     """
 
-    class Config(BaseConfig):
+    class Config(pydantic.BaseConfig):
         orm_mode = True
 
     return Config

--- a/ormar/models/helpers/related_names_validation.py
+++ b/ormar/models/helpers/related_names_validation.py
@@ -1,0 +1,43 @@
+from typing import Dict, List, Optional, TYPE_CHECKING, Type
+
+from pydantic.typing import ForwardRef
+import ormar  # noqa: I100
+
+if TYPE_CHECKING:  # pragma no cover
+    from ormar import Model
+
+
+def validate_related_names_in_relations(  # noqa CCR001
+    model_fields: Dict, new_model: Type["Model"]
+) -> None:
+    """
+    Performs a validation of relation_names in relation fields.
+    If multiple fields are leading to the same related model
+    only one can have empty related_name param
+    (populated by default as model.name.lower()+'s').
+    Also related_names have to be unique for given related model.
+
+    :raises ModelDefinitionError: if validation of related_names fail
+    :param model_fields: dictionary of declared ormar model fields
+    :type model_fields: Dict[str, ormar.Field]
+    :param new_model:
+    :type new_model: Model class
+    """
+    already_registered: Dict[str, List[Optional[str]]] = dict()
+    for field in model_fields.values():
+        if issubclass(field, ormar.ForeignKeyField):
+            to_name = (
+                field.to.get_name()
+                if not field.to.__class__ == ForwardRef
+                else str(field.to)
+            )
+            previous_related_names = already_registered.setdefault(to_name, [])
+            if field.related_name in previous_related_names:
+                raise ormar.ModelDefinitionError(
+                    f"Multiple fields declared on {new_model.get_name(lower=False)} "
+                    f"model leading to {field.to.get_name(lower=False)} model without "
+                    f"related_name property set. \nThere can be only one relation with "
+                    f"default/empty name: '{new_model.get_name() + 's'}'"
+                    f"\nTip: provide different related_name for FK and/or M2M fields"
+                )
+            previous_related_names.append(field.related_name)

--- a/ormar/models/helpers/validation.py
+++ b/ormar/models/helpers/validation.py
@@ -1,0 +1,161 @@
+import datetime
+import decimal
+import uuid
+from enum import Enum
+from typing import Any, Dict, List, TYPE_CHECKING, Tuple, Type
+
+try:
+    import orjson as json
+except ImportError:  # pragma: no cover
+    import json  # type: ignore
+
+import pydantic
+from pydantic.main import SchemaExtraCallable
+
+import ormar  # noqa: I100, I202
+from ormar.fields import BaseField
+from ormar.models.helpers.models import meta_field_not_set
+
+if TYPE_CHECKING:  # pragma no cover
+    from ormar import Model
+
+
+def check_if_field_has_choices(field: Type[BaseField]) -> bool:
+    """
+    Checks if given field has choices populated.
+    A if it has one, a validator for this field needs to be attached.
+
+    :param field: ormar field to check
+    :type field: BaseField
+    :return: result of the check
+    :rtype: bool
+    """
+    return hasattr(field, "choices") and bool(field.choices)
+
+
+def convert_choices_if_needed(  # noqa: CCR001
+    field: Type["BaseField"], value: Any
+) -> Tuple[Any, List]:
+    """
+    Converts dates to isoformat as fastapi can check this condition in routes
+    and the fields are not yet parsed.
+
+    Converts enums to list of it's values.
+
+    Converts uuids to strings.
+
+    Converts decimal to float with given scale.
+
+    :param field: ormar field to check with choices
+    :type field: Type[BaseField]
+    :param values: current values of the model to verify
+    :type values: Dict
+    :return: value, choices list
+    :rtype: Tuple[Any, List]
+    """
+    choices = [o.value if isinstance(o, Enum) else o for o in field.choices]
+
+    if field.__type__ in [datetime.datetime, datetime.date, datetime.time]:
+        value = value.isoformat() if not isinstance(value, str) else value
+        choices = [o.isoformat() for o in field.choices]
+    elif field.__type__ == pydantic.Json:
+        value = json.dumps(value) if not isinstance(value, str) else value
+        value = value.decode("utf-8") if isinstance(value, bytes) else value
+    elif field.__type__ == uuid.UUID:
+        value = str(value) if not isinstance(value, str) else value
+        choices = [str(o) for o in field.choices]
+    elif field.__type__ == decimal.Decimal:
+        precision = field.scale  # type: ignore
+        value = (
+            round(float(value), precision)
+            if isinstance(value, decimal.Decimal)
+            else value
+        )
+        choices = [round(float(o), precision) for o in choices]
+
+    return value, choices
+
+
+def validate_choices(field: Type["BaseField"], value: Any) -> None:
+    """
+    Validates if given value is in provided choices.
+
+    :raises ValueError: If value is not in choices.
+    :param field:field to validate
+    :type field: Type[BaseField]
+    :param value: value of the field
+    :type value: Any
+    """
+    value, choices = convert_choices_if_needed(field=field, value=value)
+    if value is not ormar.Undefined and value not in choices:
+        raise ValueError(
+            f"{field.name}: '{value}' " f"not in allowed choices set:" f" {choices}"
+        )
+
+
+def choices_validator(cls: Type["Model"], values: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Validator that is attached to pydantic model pre root validators.
+    Validator checks if field value is in field.choices list.
+
+    :raises ValueError: if field value is outside of allowed choices.
+    :param cls: constructed class
+    :type cls: Model class
+    :param values: dictionary of field values (pydantic side)
+    :type values: Dict[str, Any]
+    :return: values if pass validation, otherwise exception is raised
+    :rtype: Dict[str, Any]
+    """
+    for field_name, field in cls.Meta.model_fields.items():
+        if check_if_field_has_choices(field):
+            value = values.get(field_name, ormar.Undefined)
+            validate_choices(field=field, value=value)
+    return values
+
+
+def construct_modify_schema_function(fields_with_choices: List) -> SchemaExtraCallable:
+    """
+    Modifies the schema to include fields with choices validator.
+    Those fields will be displayed in schema as Enum types with available choices
+    values listed next to them.
+
+    :param fields_with_choices: list of fields with choices validation
+    :type fields_with_choices: List
+    :return: callable that will be run by pydantic to modify the schema
+    :rtype: Callable
+    """
+
+    def schema_extra(schema: Dict[str, Any], model: Type["Model"]) -> None:
+        for field_id, prop in schema.get("properties", {}).items():
+            if field_id in fields_with_choices:
+                prop["enum"] = list(model.Meta.model_fields[field_id].choices)
+                prop["description"] = prop.get("description", "") + "An enumeration."
+
+    return staticmethod(schema_extra)  # type: ignore
+
+
+def populate_choices_validators(model: Type["Model"]) -> None:  # noqa CCR001
+    """
+    Checks if Model has any fields with choices set.
+    If yes it adds choices validation into pre root validators.
+
+    :param model: newly constructed Model
+    :type model: Model class
+    """
+    fields_with_choices = []
+    if not meta_field_not_set(model=model, field_name="model_fields"):
+        for name, field in model.Meta.model_fields.items():
+            if check_if_field_has_choices(field):
+                fields_with_choices.append(name)
+                validators = getattr(model, "__pre_root_validators__", [])
+                if choices_validator not in validators:
+                    validators.append(choices_validator)
+                    model.__pre_root_validators__ = validators
+                if not model._choices_fields:
+                    model._choices_fields = set()
+                model._choices_fields.add(name)
+
+        if fields_with_choices:
+            model.Config.schema_extra = construct_modify_schema_function(
+                fields_with_choices=fields_with_choices
+            )

--- a/ormar/models/quick_access_views.py
+++ b/ormar/models/quick_access_views.py
@@ -16,6 +16,7 @@ quick_access_set = {
     "__pre_root_validators__",
     "__same__",
     "_calculate_keys",
+    "_choices_fields",
     "_convert_json",
     "_extract_db_related_names",
     "_extract_model_db_fields",

--- a/ormar/queryset/queryset.py
+++ b/ormar/queryset/queryset.py
@@ -555,6 +555,7 @@ class QuerySet:
             self.model.extract_related_names()
         )
         updates = {k: v for k, v in kwargs.items() if k in self_fields}
+        updates = self.model.validate_choices(updates)
         updates = self.model.translate_columns_to_aliases(updates)
         if not each and not self.filter_clauses:
             raise QueryDefinitionError(

--- a/ormar/relations/relation.py
+++ b/ormar/relations/relation.py
@@ -64,7 +64,7 @@ class Relation:
         self._to_remove: Set = set()
         self.to: Type["T"] = to
         self._through: Optional[Type["T"]] = through
-        self.field_name = field_name
+        self.field_name: str = field_name
         self.related_models: Optional[Union[RelationProxy, "T"]] = (
             RelationProxy(relation=self, type_=type_, field_name=field_name)
             if type_ in (RelationType.REVERSE, RelationType.MULTIPLE)

--- a/tests/test_json_field_fastapi.py
+++ b/tests/test_json_field_fastapi.py
@@ -115,15 +115,16 @@ async def test_json_is_not_required_if_nullable():
 
 @pytest.mark.asyncio
 async def test_setting_values_after_init():
-    t1 = Thing(id="67a82813-d90c-45ff-b546-b4e38d7030d7", name="t1", js=["thing1"])
-    assert '["thing1"]' in t1.json()
-    await t1.save()
-    t1.json()
-    assert '["thing1"]' in t1.json()
+    async with database:
+        t1 = Thing(id="67a82813-d90c-45ff-b546-b4e38d7030d7", name="t1", js=["thing1"])
+        assert '["thing1"]' in t1.json()
+        await t1.save()
+        t1.json()
+        assert '["thing1"]' in t1.json()
 
-    assert '["thing1"]' in (await Thing.objects.get(id=t1.id)).json()
-    await t1.update()
-    assert '["thing1"]' in (await Thing.objects.get(id=t1.id)).json()
+        assert '["thing1"]' in (await Thing.objects.get(id=t1.id)).json()
+        await t1.update()
+        assert '["thing1"]' in (await Thing.objects.get(id=t1.id)).json()
 
 
 def test_read_main():

--- a/tests/test_json_field_fastapi.py
+++ b/tests/test_json_field_fastapi.py
@@ -1,0 +1,122 @@
+import uuid
+from typing import List
+
+import databases
+import pydantic
+import pytest
+import sqlalchemy
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+import ormar
+from tests.settings import DATABASE_URL
+
+app = FastAPI()
+
+database = databases.Database(DATABASE_URL, force_rollback=True)
+metadata = sqlalchemy.MetaData()
+app.state.database = database
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    database_ = app.state.database
+    if not database_.is_connected:
+        await database_.connect()
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    database_ = app.state.database
+    if database_.is_connected:
+        await database_.disconnect()
+
+
+class BaseMeta(ormar.ModelMeta):
+    metadata = metadata
+    database = database
+
+
+class Thing(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "things"
+
+    id: uuid.UUID = ormar.UUID(primary_key=True, default=uuid.uuid4)
+    name: str = ormar.Text(default="")
+    js: pydantic.Json = ormar.JSON()
+
+
+@app.get("/things", response_model=List[Thing])
+async def read_things():
+    return await Thing.objects.order_by("name").all()
+
+
+@app.get("/things_with_sample", response_model=List[Thing])
+async def read_things():
+    await Thing(name="b", js=["asdf", "asdf", "bobby", "nigel"]).save()
+    await Thing(name="a", js="[\"lemon\", \"raspberry\", \"lime\", \"pumice\"]").save()
+    return await Thing.objects.order_by("name").all()
+
+
+@app.get("/things_with_sample_after_init", response_model=Thing)
+async def read_things():
+    thing1 = Thing()
+    thing1.name = "d"
+    thing1.js = ["js", "set", "after", "constructor"]
+    await thing1.save()
+    return thing1
+
+
+@app.post("/things", response_model=Thing)
+async def create_things(thing: Thing):
+    thing = await thing.save()
+    return thing
+
+
+@pytest.fixture(autouse=True, scope="module")
+def create_test_database():
+    engine = sqlalchemy.create_engine(DATABASE_URL)
+    metadata.create_all(engine)
+    yield
+    metadata.drop_all(engine)
+
+
+def test_read_main():
+    client = TestClient(app)
+    with client as client:
+        response = client.get("/things_with_sample")
+        assert response.status_code == 200
+
+        # check if raw response not double encoded
+        assert '["lemon","raspberry","lime","pumice"]' in response.text
+
+        # parse json and check that we get lists not strings
+        resp = response.json()
+        assert resp[0].get("js") == ["lemon", "raspberry", "lime", "pumice"]
+        assert resp[1].get("js") == ["asdf", "asdf", "bobby", "nigel"]
+
+        # create a new one
+        response = client.post("/things", json={"js": ["test", "test2"], "name": "c"})
+        assert response.json().get("js") == ["test", "test2"]
+
+        # get all with new one
+        response = client.get("/things")
+        assert response.status_code == 200
+        assert '["test","test2"]' in response.text
+        resp = response.json()
+        assert resp[0].get("js") == ["lemon", "raspberry", "lime", "pumice"]
+        assert resp[1].get("js") == ["asdf", "asdf", "bobby", "nigel"]
+        assert resp[2].get("js") == ["test", "test2"]
+
+        response = client.get("/things_with_sample_after_init")
+        assert response.status_code == 200
+        resp = response.json()
+        assert resp.get("js") == ["js", "set", "after", "constructor"]
+
+        # test new with after constructor
+        response = client.get("/things")
+        resp = response.json()
+        assert resp[0].get("js") == ["lemon", "raspberry", "lime", "pumice"]
+        assert resp[1].get("js") == ["asdf", "asdf", "bobby", "nigel"]
+        assert resp[2].get("js") == ["test", "test2"]
+        assert resp[3].get("js") == ["js", "set", "after", "constructor"]

--- a/tests/test_m2m_through_fields.py
+++ b/tests/test_m2m_through_fields.py
@@ -38,6 +38,7 @@ class Post(ormar.Model):
     title: str = ormar.String(max_length=200)
     categories = ormar.ManyToMany(Category, through=PostCategory)
 
+
 #
 # @pytest.fixture(autouse=True, scope="module")
 # async def create_test_database():

--- a/tests/test_m2m_through_fields.py
+++ b/tests/test_m2m_through_fields.py
@@ -1,0 +1,65 @@
+import databases
+import pytest
+import sqlalchemy
+
+import ormar
+from tests.settings import DATABASE_URL
+
+database = databases.Database(DATABASE_URL, force_rollback=True)
+metadata = sqlalchemy.MetaData()
+
+
+class BaseMeta(ormar.ModelMeta):
+    database = database
+    metadata = metadata
+
+
+class Category(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "categories"
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=40)
+
+
+class PostCategory(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "posts_x_categories"
+
+    id: int = ormar.Integer(primary_key=True)
+    sort_order: int = ormar.Integer(nullable=True)
+
+
+class Post(ormar.Model):
+    class Meta(BaseMeta):
+        pass
+
+    id: int = ormar.Integer(primary_key=True)
+    title: str = ormar.String(max_length=200)
+    categories = ormar.ManyToMany(Category, through=PostCategory)
+
+
+@pytest.fixture(autouse=True, scope="module")
+async def create_test_database():
+    engine = sqlalchemy.create_engine(DATABASE_URL)
+    metadata.create_all(engine)
+    yield
+    metadata.drop_all(engine)
+
+
+@pytest.mark.asyncio
+async def test_setting_fields_on_through_model():
+    async with database:
+        # TODO: check/ modify following
+        # loading the data into model instance of though model?
+        # <- attach to other side? both sides? access by through, or add to fields?
+        # creating while adding to relation (kwargs in add?)
+        # creating in query (dividing kwargs between final and through)
+        # updating in query
+        # sorting in filter (special __through__<field_name> notation?)
+        # ordering by in order_by
+        # accessing from instance (both sides?)
+        # modifying from instance (both sides?)
+        # including/excluding in fields?
+        # allowing to change fk fields names in through model?
+        pass

--- a/tests/test_m2m_through_fields.py
+++ b/tests/test_m2m_through_fields.py
@@ -38,28 +38,28 @@ class Post(ormar.Model):
     title: str = ormar.String(max_length=200)
     categories = ormar.ManyToMany(Category, through=PostCategory)
 
-
-@pytest.fixture(autouse=True, scope="module")
-async def create_test_database():
-    engine = sqlalchemy.create_engine(DATABASE_URL)
-    metadata.create_all(engine)
-    yield
-    metadata.drop_all(engine)
-
-
-@pytest.mark.asyncio
-async def test_setting_fields_on_through_model():
-    async with database:
-        # TODO: check/ modify following
-        # loading the data into model instance of though model?
-        # <- attach to other side? both sides? access by through, or add to fields?
-        # creating while adding to relation (kwargs in add?)
-        # creating in query (dividing kwargs between final and through)
-        # updating in query
-        # sorting in filter (special __through__<field_name> notation?)
-        # ordering by in order_by
-        # accessing from instance (both sides?)
-        # modifying from instance (both sides?)
-        # including/excluding in fields?
-        # allowing to change fk fields names in through model?
-        pass
+#
+# @pytest.fixture(autouse=True, scope="module")
+# async def create_test_database():
+#     engine = sqlalchemy.create_engine(DATABASE_URL)
+#     metadata.create_all(engine)
+#     yield
+#     metadata.drop_all(engine)
+#
+#
+# @pytest.mark.asyncio
+# async def test_setting_fields_on_through_model():
+#     async with database:
+#         # TODO: check/ modify following
+#         # loading the data into model instance of though model?
+#         # <- attach to other side? both sides? access by through, or add to fields?
+#         # creating while adding to relation (kwargs in add?)
+#         # creating in query (dividing kwargs between final and through)
+#         # updating in query
+#         # sorting in filter (special __through__<field_name> notation?)
+#         # ordering by in order_by
+#         # accessing from instance (both sides?)
+#         # modifying from instance (both sides?)
+#         # including/excluding in fields?
+#         # allowing to change fk fields names in through model?
+#         pass


### PR DESCRIPTION
## Fixes
* Fix `JSON` field being double escaped when setting value after initialization
* Fix `JSON` field not respecting `nullable` field setting due to `pydantic` internals 
* Fix `choices` verification for `JSON` field
* Fix `choices` not being verified when setting the attribute after initialization
* Fix `choices` not being verified during `update` call from `QuerySet`
