### PR TITLE
fix multiple pkonly models with same name in openapi schema

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,3 +1,9 @@
+# 0.9.4
+
+## Fixes
+* Fix `fastapi` OpenAPI schema generation for automatic docs when multiple models refer to the same related one
+
+
 # 0.9.3
 
 ## Fixes

--- a/ormar/__init__.py
+++ b/ormar/__init__.py
@@ -68,7 +68,7 @@ class UndefinedType:  # pragma no cover
 
 Undefined = UndefinedType()
 
-__version__ = "0.9.3"
+__version__ = "0.9.4"
 __all__ = [
     "Integer",
     "BigInteger",

--- a/ormar/fields/foreign_key.py
+++ b/ormar/fields/foreign_key.py
@@ -1,6 +1,8 @@
+import string
 import sys
 import uuid
 from dataclasses import dataclass
+from random import choices
 from typing import Any, List, Optional, TYPE_CHECKING, Tuple, Type, Union
 
 import sqlalchemy
@@ -67,9 +69,14 @@ def create_dummy_model(
     :return: constructed dummy model
     :rtype: pydantic.BaseModel
     """
+    alias = (
+        "".join(choices(string.ascii_uppercase, k=2)) + uuid.uuid4().hex[:4]
+    ).lower()
     fields = {f"{pk_field.name}": (pk_field.__type__, None)}
     dummy_model = create_model(
-        f"PkOnly{base_model.get_name(lower=False)}", **fields  # type: ignore
+        f"PkOnly{base_model.get_name(lower=False)}{alias}",
+        __module__=base_model.__module__,
+        **fields,  # type: ignore
     )
     return dummy_model
 

--- a/tests/test_docs_with_multiple_relations_to_one.py
+++ b/tests/test_docs_with_multiple_relations_to_one.py
@@ -46,17 +46,17 @@ class CB2(ormar.Model):
 
 
 @app.get("/ca", response_model=CA)
-async def get_ca():
+async def get_ca():  # pragma: no cover
     return None
 
 
 @app.get("/cb1", response_model=CB1)
-async def get_cb1():
+async def get_cb1():  # pragma: no cover
     return None
 
 
 @app.get("/cb2", response_model=CB2)
-async def get_cb2():
+async def get_cb2():  # pragma: no cover
     return None
 
 

--- a/tests/test_docs_with_multiple_relations_to_one.py
+++ b/tests/test_docs_with_multiple_relations_to_one.py
@@ -1,0 +1,72 @@
+from typing import Optional
+from uuid import UUID, uuid4
+
+import databases
+import sqlalchemy
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+import ormar
+
+app = FastAPI()
+DATABASE_URL = "sqlite:///db.sqlite"
+database = databases.Database(DATABASE_URL)
+metadata = sqlalchemy.MetaData()
+
+
+class BaseMeta(ormar.ModelMeta):
+    metadata = metadata
+    database = database
+
+
+class CA(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "cas"
+
+    id: UUID = ormar.UUID(primary_key=True, default=uuid4)
+    ca_name: str = ormar.Text(default="")
+
+
+class CB1(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "cb1s"
+
+    id: UUID = ormar.UUID(primary_key=True, default=uuid4)
+    cb1_name: str = ormar.Text(default="")
+    ca1: Optional[CA] = ormar.ForeignKey(CA, nullable=True)
+
+
+class CB2(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "cb2s"
+
+    id: UUID = ormar.UUID(primary_key=True, default=uuid4)
+    cb2_name: str = ormar.Text(default="")
+    ca2: Optional[CA] = ormar.ForeignKey(CA, nullable=True)
+
+
+@app.get("/ca", response_model=CA)
+async def get_ca():
+    return None
+
+
+@app.get("/cb1", response_model=CB1)
+async def get_cb1():
+    return None
+
+
+@app.get("/cb2", response_model=CB2)
+async def get_cb2():
+    return None
+
+
+def test_all_endpoints():
+    client = TestClient(app)
+    with client as client:
+        response = client.get("/openapi.json")
+        assert response.status_code == 200, response.text
+        schema = response.json()
+        components = schema["components"]["schemas"]
+        assert all(x in components for x in ["CA", "CB1", "CB2"])
+        pk_onlys = [x for x in list(components.keys()) if x.startswith("PkOnly")]
+        assert len(pk_onlys) == 2


### PR DESCRIPTION
## Fixes
* Fix `fastapi` OpenAPI schema generation for automatic docs when multiple models refer to the same related one
