### PR TITLE
Isnull filters and complex filters (including or)

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -51,13 +51,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Run postgres
-      env:
-        DATABASE_URL: "postgresql://username:password@localhost:5432/testsuite"
-      run: bash scripts/test.sh
     - name: Run mysql
       env:
         DATABASE_URL: "mysql://username:password@127.0.0.1:3306/testsuite"
+      run: bash scripts/test.sh
+    - name: Run postgres
+      env:
+        DATABASE_URL: "postgresql://username:password@localhost:5432/testsuite"
       run: bash scripts/test.sh
     - name: Run sqlite
       env:

--- a/docs/queries/filter-and-sort.md
+++ b/docs/queries/filter-and-sort.md
@@ -26,7 +26,7 @@ And following methods to sort the data (sql order by clause).
 
 ### filter
 
-`filter(**kwargs) -> QuerySet`
+`filter(*args, **kwargs) -> QuerySet`
 
 Allows you to filter by any `Model` attribute/field as well as to fetch instances, with
 a filter across an FK relationship.
@@ -97,7 +97,7 @@ You can use special filter suffix to change the filter operands:
 
 ### exclude
 
-`exclude(**kwargs) -> QuerySet`
+`exclude(*args, **kwargs) -> QuerySet`
 
 Works exactly the same as filter and all modifiers (suffixes) are the same, but returns
 a not condition.
@@ -138,6 +138,181 @@ class Track(ormar.Model):
 notes = await Track.objects.exclude(position_gt=3).all()
 # returns all tracks with position < 3
 ```
+
+## Complex filters (including OR)
+
+By default both `filter()` and `exclude()` methods combine provided filter options with
+`AND` condition so `filter(name="John", age__gt=30)` translates into `WHERE name = 'John' AND age > 30`.
+
+Sometimes it's useful to query the database with conditions that should not be applied 
+jointly like `WHERE name = 'John' OR age > 30`, or build a complex where query that you would
+like to have bigger control over. After all `WHERE (name = 'John' OR age > 30) and city='New York'` is
+completely different than `WHERE name = 'John' OR (age > 30 and city='New York')`.
+
+In order to build `OR` and nested conditions ormar provides two functions that can be used in 
+`filter()` and `exclude()` in `QuerySet` and `QuerysetProxy`. 
+
+!!!note
+    Note that you cannot provide those methods in any other method like `get()` or `all()` which accepts only keyword arguments. 
+
+Call to `or_` and `and_` can be nested in each other, as well as combined with keyword arguments.
+Since it sounds more complicated than it is, let's look at some examples.
+
+Given a sample models like this:
+```python
+database = databases.Database(DATABASE_URL)
+metadata = sqlalchemy.MetaData()
+
+
+class BaseMeta(ormar.ModelMeta):
+    metadata = metadata
+    database = database
+
+
+class Author(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "authors"
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+
+
+class Book(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "books"
+
+    id: int = ormar.Integer(primary_key=True)
+    author: Optional[Author] = ormar.ForeignKey(Author)
+    title: str = ormar.String(max_length=100)
+    year: int = ormar.Integer(nullable=True)
+```
+
+Let's create some sample data:
+
+```python
+tolkien = await Author(name="J.R.R. Tolkien").save()
+await Book(author=tolkien, title="The Hobbit", year=1933).save()
+await Book(author=tolkien, title="The Lord of the Rings", year=1955).save()
+await Book(author=tolkien, title="The Silmarillion", year=1977).save()
+sapkowski = await Author(name="Andrzej Sapkowski").save()
+await Book(author=sapkowski, title="The Witcher", year=1990).save()
+await Book(author=sapkowski, title="The Tower of Fools", year=2002).save()
+```
+
+We can construct some sample complex queries:
+
+Let's select books of Tolkien **OR** books written after 1970
+
+sql:
+`WHERE ( authors.name = 'J.R.R. Tolkien' OR books.year > 1970 )`
+
+```python
+books = (
+    await Book.objects.select_related("author")
+    .filter(ormar.or_(author__name="J.R.R. Tolkien", year__gt=1970))
+    .all()
+)
+assert len(books) == 5
+```
+
+Now let's select books written after 1960 or before 1940 which were written by Tolkien.
+
+sql:
+`WHERE ( books.year > 1960 OR books.year < 1940 ) AND authors.name = 'J.R.R. Tolkien'`
+
+```python
+# OPTION 1 - split and into separate call
+books = (
+    await Book.objects.select_related("author")
+    .filter(ormar.or_(year__gt=1960, year__lt=1940))
+    .filter(author__name="J.R.R. Tolkien")
+    .all()
+)
+assert len(books) == 2
+
+# OPTION 2 - all in one
+books = (
+    await Book.objects.select_related("author")
+    .filter(
+        ormar.and_(
+            ormar.or_(year__gt=1960, year__lt=1940),
+            author__name="J.R.R. Tolkien",
+        )
+    )
+    .all()
+)
+
+assert len(books) == 2
+assert books[0].title == "The Hobbit"
+assert books[1].title == "The Silmarillion"
+```
+
+Books of Sapkowski from before 2000 or books of Tolkien written after 1960
+
+sql:
+`WHERE ( ( books.year > 1960 AND authors.name = 'J.R.R. Tolkien' ) OR ( books.year < 2000 AND authors.name = 'Andrzej Sapkowski' ) ) `
+
+```python
+books = (
+    await Book.objects.select_related("author")
+    .filter(
+        ormar.or_(
+            ormar.and_(year__gt=1960, author__name="J.R.R. Tolkien"),
+            ormar.and_(year__lt=2000, author__name="Andrzej Sapkowski"),
+        )
+    )
+    .all()
+)
+assert len(books) == 2
+```
+
+Of course those functions can have more than 2 conditions, so if we for example want also 
+books that contains 'hobbit':
+
+sql:
+`WHERE ( ( books.year > 1960 AND authors.name = 'J.R.R. Tolkien' ) OR 
+( books.year < 2000 AND os0cec_authors.name = 'Andrzej Sapkowski' ) OR 
+books.title LIKE '%hobbit%' )`
+
+```python
+books = (
+    await Book.objects.select_related("author")
+    .filter(
+        ormar.or_(
+            ormar.and_(year__gt=1960, author__name="J.R.R. Tolkien"),
+            ormar.and_(year__lt=2000, author__name="Andrzej Sapkowski"),
+            title__icontains="hobbit",
+        )
+    )
+    .all()
+)
+```
+
+By now you should already have an idea how `ormar.or_` and `ormar.and_` works.
+Of course, you could chain them in any other methods of queryset, so in example a perfectly
+valid query can look like follows:
+
+```python
+books = (
+    await Book.objects.select_related("author")
+    .filter(ormar.or_(year__gt=1980, author__name="Andrzej Sapkowski"))
+    .filter(title__startswith="The")
+    .limit(1)
+    .offset(1)
+    .order_by("-id")
+    .all()
+)
+assert len(books) == 1
+assert books[0].title == "The Witcher"
+```
+
+
+!!!note
+    Note that you cannot provide the same keyword argument several times so queries like `filter(ormar.or_(name='Jack', name='John'))` are not allowed. If you want to check the same
+    column for several values simply use `in` operator: `filter(name__in=['Jack','John'])`.
+    Note that also that technically you can still do `filter(ormar.or_(name='Jack', name__exact='John'))`
+    but it's not recommended. The different operators can be used as long as they do not
+    repeat so `filter(ormar.or_(year__lt=1560, year__gt=2000))` is fine.
 
 ## get
 

--- a/docs/queries/filter-and-sort.md
+++ b/docs/queries/filter-and-sort.md
@@ -70,6 +70,8 @@ You can use special filter suffix to change the filter operands:
 * contains - like `album__name__contains='Mal'` (sql like)
 * icontains - like `album__name__icontains='mal'` (sql like case insensitive)
 * in - like `album__name__in=['Malibu', 'Barclay']` (sql in)
+*  isnull - like `album__name__isnull=True` (sql is null)
+   (isnotnull `album__name__isnull=False` (sql is not null))
 * gt - like `position__gt=3` (sql >)
 * gte - like `position__gte=3` (sql >=)
 * lt - like `position__lt=3` (sql <)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,3 +1,13 @@
+# 0.9.7
+
+## Features
+* Add `isnull` operator to filter and exclude methods. 
+    ```python
+    album__name__isnull=True #(sql: album.name is null)
+    album__name__isnull=False #(sql: album.name is not null))
+    ```
+
+
 # 0.9.6
 
 ##Important

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,7 +6,22 @@
     album__name__isnull=True #(sql: album.name is null)
     album__name__isnull=False #(sql: album.name is not null))
     ```
-
+* Add `ormar.or_` and `ormar.and_` functions that can be used to compose
+  complex queries with nested conditions. 
+  Sample query:
+  ```python
+  books = (
+      await Book.objects.select_related("author")
+      .filter(
+          ormar.and_(
+              ormar.or_(year__gt=1960, year__lt=1940),
+              author__name="J.R.R. Tolkien",
+          )
+      )
+      .all()
+  )
+  ```
+  Check the updated docs in Queries -> Filtering and sorting -> Complex filters
 
 # 0.9.6
 

--- a/ormar/__init__.py
+++ b/ormar/__init__.py
@@ -56,7 +56,7 @@ from ormar.fields import (
 )  # noqa: I100
 from ormar.models import ExcludableItems, Model
 from ormar.models.metaclass import ModelMeta
-from ormar.queryset import OrderAction, QuerySet
+from ormar.queryset import OrderAction, QuerySet, and_, or_
 from ormar.relations import RelationType
 from ormar.signals import Signal
 
@@ -68,7 +68,7 @@ class UndefinedType:  # pragma no cover
 
 Undefined = UndefinedType()
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"
 __all__ = [
     "Integer",
     "BigInteger",
@@ -108,4 +108,6 @@ __all__ = [
     "ForeignKeyField",
     "OrderAction",
     "ExcludableItems",
+    "and_",
+    "or_",
 ]

--- a/ormar/fields/base.py
+++ b/ormar/fields/base.py
@@ -1,4 +1,3 @@
-import inspect
 from typing import Any, List, Optional, TYPE_CHECKING, Type, Union
 
 import sqlalchemy

--- a/ormar/fields/foreign_key.py
+++ b/ormar/fields/foreign_key.py
@@ -75,7 +75,6 @@ def create_dummy_model(
     fields = {f"{pk_field.name}": (pk_field.__type__, None)}
 
     dummy_model = create_model(  # type: ignore
-
         f"PkOnly{base_model.get_name(lower=False)}{alias}",
         __module__=base_model.__module__,
         **fields,  # type: ignore

--- a/ormar/models/newbasemodel.py
+++ b/ormar/models/newbasemodel.py
@@ -227,7 +227,7 @@ class NewBaseModel(pydantic.BaseModel, ModelTableProxy, metaclass=ModelMetaclass
             super().__setattr__(name, value)
             self.set_save_status(False)
 
-    def __getattribute__(self, item: str) -> Any:
+    def __getattribute__(self, item: str) -> Any:  # noqa: CCR001
         """
         Because we need to overwrite getting the attribute by ormar instead of pydantic
         as well as returning related models and not the value stored on the model the

--- a/ormar/queryset/__init__.py
+++ b/ormar/queryset/__init__.py
@@ -2,6 +2,7 @@
 Contains QuerySet and different Query classes to allow for constructing of sql queries.
 """
 from ormar.queryset.actions import FilterAction, OrderAction
+from ormar.queryset.clause import and_, or_
 from ormar.queryset.filter_query import FilterQuery
 from ormar.queryset.limit_query import LimitQuery
 from ormar.queryset.offset_query import OffsetQuery
@@ -16,4 +17,6 @@ __all__ = [
     "OrderQuery",
     "FilterAction",
     "OrderAction",
+    "and_",
+    "or_",
 ]

--- a/ormar/queryset/actions/filter_action.py
+++ b/ormar/queryset/actions/filter_action.py
@@ -19,6 +19,7 @@ FILTER_OPERATORS = {
     "istartswith": "ilike",
     "endswith": "like",
     "iendswith": "ilike",
+    "isnull": "is_",
     "in": "in_",
     "gt": "__gt__",
     "gte": "__ge__",
@@ -38,7 +39,7 @@ class FilterAction(QueryAction):
     Extracted in order to easily change table prefixes on complex relations.
     """
 
-    def __init__(self, filter_str: str, value: Any, model_cls: Type["Model"]) -> None:
+    def __init__(self, filter_str: str, value: Any, model_cls: Type["Model"],) -> None:
         super().__init__(query_str=filter_str, model_cls=model_cls)
         self.filter_value = value
         self._escape_characters_in_clause()
@@ -124,6 +125,9 @@ class FilterAction(QueryAction):
             self.filter_value = self.filter_value.pk
 
         op_attr = FILTER_OPERATORS[self.operator]
+        if self.operator == "isnull":
+            op_attr = "is_" if self.filter_value else "isnot"
+            self.filter_value = None
         clause = getattr(self.column, op_attr)(self.filter_value)
         clause = self._compile_clause(
             clause, modifiers={"escape": "\\" if self.has_escaped_character else None},

--- a/ormar/queryset/actions/filter_action.py
+++ b/ormar/queryset/actions/filter_action.py
@@ -43,9 +43,6 @@ class FilterAction(QueryAction):
         super().__init__(query_str=filter_str, model_cls=model_cls)
         self.filter_value = value
         self._escape_characters_in_clause()
-        self.is_source_model_filter = False
-        if self.source_model == self.target_model and "__" not in self.related_str:
-            self.is_source_model_filter = True
 
     def has_escaped_characters(self) -> bool:
         """Check if value is a string that contains characters to escape"""

--- a/ormar/queryset/actions/order_action.py
+++ b/ormar/queryset/actions/order_action.py
@@ -46,6 +46,13 @@ class OrderAction(QueryAction):
         prefix = f"{self.table_prefix}_" if self.table_prefix else ""
         return f"{prefix}{self.table}" f".{self.field_alias}"
 
+    def get_min_or_max(self):
+        prefix = f"{self.table_prefix}_" if self.table_prefix else ""
+        if self.direction == '':
+            return text(f"min({prefix}{self.table}" f".{self.field_alias})")
+        else:
+            return text(f"max({prefix}{self.table}" f".{self.field_alias}) desc")
+
     def get_text_clause(self) -> sqlalchemy.sql.expression.TextClause:
         """
         Escapes characters if it's required.

--- a/ormar/queryset/actions/order_action.py
+++ b/ormar/queryset/actions/order_action.py
@@ -20,7 +20,7 @@ class OrderAction(QueryAction):
     """
 
     def __init__(
-            self, order_str: str, model_cls: Type["Model"], alias: str = None
+        self, order_str: str, model_cls: Type["Model"], alias: str = None
     ) -> None:
         self.direction: str = ""
         super().__init__(query_str=order_str, model_cls=model_cls)
@@ -46,9 +46,16 @@ class OrderAction(QueryAction):
         prefix = f"{self.table_prefix}_" if self.table_prefix else ""
         return f"{prefix}{self.table}" f".{self.field_alias}"
 
-    def get_min_or_max(self):
+    def get_min_or_max(self) -> sqlalchemy.sql.expression.TextClause:
+        """
+        Used in limit sub queries where you need to use aggregated functions
+        in order to order by columns not included in group by.
+
+        :return: min or max function to order
+        :rtype: sqlalchemy.sql.elements.TextClause
+        """
         prefix = f"{self.table_prefix}_" if self.table_prefix else ""
-        if self.direction == '':
+        if self.direction == "":
             return text(f"min({prefix}{self.table}" f".{self.field_alias})")
         else:
             return text(f"max({prefix}{self.table}" f".{self.field_alias}) desc")

--- a/ormar/queryset/actions/order_action.py
+++ b/ormar/queryset/actions/order_action.py
@@ -20,7 +20,7 @@ class OrderAction(QueryAction):
     """
 
     def __init__(
-        self, order_str: str, model_cls: Type["Model"], alias: str = None
+            self, order_str: str, model_cls: Type["Model"], alias: str = None
     ) -> None:
         self.direction: str = ""
         super().__init__(query_str=order_str, model_cls=model_cls)
@@ -33,6 +33,18 @@ class OrderAction(QueryAction):
     @property
     def field_alias(self) -> str:
         return self.target_model.get_column_alias(self.field_name)
+
+    def get_field_name_text(self) -> str:
+        """
+        Escapes characters if it's required.
+        Substitutes values of the models if value is a ormar Model with its pk value.
+        Compiles the clause.
+
+        :return: complied and escaped clause
+        :rtype: sqlalchemy.sql.elements.TextClause
+        """
+        prefix = f"{self.table_prefix}_" if self.table_prefix else ""
+        return f"{prefix}{self.table}" f".{self.field_alias}"
 
     def get_text_clause(self) -> sqlalchemy.sql.expression.TextClause:
         """

--- a/ormar/queryset/clause.py
+++ b/ormar/queryset/clause.py
@@ -1,6 +1,9 @@
 import itertools
 from dataclasses import dataclass
-from typing import Any, List, TYPE_CHECKING, Tuple, Type
+from enum import Enum
+from typing import Any, Generator, List, TYPE_CHECKING, Tuple, Type
+
+import sqlalchemy
 
 import ormar  # noqa I100
 from ormar.queryset.actions.filter_action import FilterAction
@@ -8,6 +11,99 @@ from ormar.queryset.utils import get_relationship_alias_model_and_str
 
 if TYPE_CHECKING:  # pragma no cover
     from ormar import Model
+
+
+class FilterType(Enum):
+    AND = 1
+    OR = 2
+
+
+class FilterGroup:
+    def __init__(
+        self, *args: Any, _filter_type: FilterType = FilterType.AND, **kwargs: Any,
+    ) -> None:
+        self.filter_type = _filter_type
+        self.exclude = False
+        self._nested_groups: List["FilterGroup"] = list(args)
+        self._resolved = False
+        self.is_source_model_filter = False
+        self._kwargs_dict = kwargs
+        self.actions: List[FilterAction] = []
+
+    def resolve(
+        self,
+        model_cls: Type["Model"],
+        select_related: List = None,
+        filter_clauses: List = None,
+    ) -> Tuple[List[FilterAction], List[str]]:
+        select_related = select_related if select_related is not None else []
+        filter_clauses = filter_clauses if filter_clauses is not None else []
+        qryclause = QueryClause(
+            model_cls=model_cls,
+            select_related=select_related,
+            filter_clauses=filter_clauses,
+        )
+        own_filter_clauses, select_related = qryclause.prepare_filter(
+            _own_only=True, **self._kwargs_dict
+        )
+        self.actions = own_filter_clauses
+        filter_clauses = filter_clauses + own_filter_clauses
+        self._resolved = True
+        if self._nested_groups:
+            for group in self._nested_groups:
+                if not group._resolved:
+                    (filter_clauses, select_related) = group.resolve(
+                        model_cls=model_cls,
+                        select_related=select_related,
+                        filter_clauses=filter_clauses,
+                    )
+        self._is_self_model_group()
+        return filter_clauses, select_related
+
+    def _iter(self) -> Generator:
+        if not self._nested_groups:
+            yield from self.actions
+            return
+        for group in self._nested_groups:
+            yield from group._iter()
+        yield from self.actions
+
+    def _is_self_model_group(self) -> None:
+        if self.actions and self._nested_groups:
+            if all([action.is_source_model_filter for action in self.actions]) and all(
+                group.is_source_model_filter for group in self._nested_groups
+            ):
+                self.is_source_model_filter = True
+        elif self.actions:
+            if all([action.is_source_model_filter for action in self.actions]):
+                self.is_source_model_filter = True
+        else:
+            if all(group.is_source_model_filter for group in self._nested_groups):
+                self.is_source_model_filter = True
+
+    def _get_text_clauses(self) -> List[sqlalchemy.sql.expression.TextClause]:
+        return [x.get_text_clause() for x in self._nested_groups] + [
+            x.get_text_clause() for x in self.actions
+        ]
+
+    def get_text_clause(self) -> sqlalchemy.sql.expression.TextClause:
+        if self.filter_type == FilterType.AND:
+            clause = sqlalchemy.text(
+                "( " + str(sqlalchemy.sql.and_(*self._get_text_clauses())) + " )"
+            )
+        else:
+            clause = sqlalchemy.text(
+                "( " + str(sqlalchemy.sql.or_(*self._get_text_clauses())) + " )"
+            )
+        return clause
+
+
+def or_(*args: Any, **kwargs: Any) -> FilterGroup:
+    return FilterGroup(_filter_type=FilterType.OR, *args, **kwargs)
+
+
+def and_(*args: Any, **kwargs: Any) -> FilterGroup:
+    return FilterGroup(_filter_type=FilterType.AND, *args, **kwargs)
 
 
 @dataclass
@@ -40,13 +136,15 @@ class QueryClause:
         self.table = self.model_cls.Meta.table
 
     def prepare_filter(  # noqa: A003
-        self, **kwargs: Any
+        self, _own_only: bool = False, **kwargs: Any
     ) -> Tuple[List[FilterAction], List[str]]:
         """
         Main external access point that processes the clauses into sqlalchemy text
         clauses and updates select_related list with implicit related tables
         mentioned in select_related strings but not included in select_related.
 
+        :param _own_only:
+        :type _own_only:
         :param kwargs: key, value pair with column names and values
         :type kwargs: Any
         :return: Tuple with list of where clauses and updated select_related list
@@ -56,12 +154,14 @@ class QueryClause:
             pk_name = self.model_cls.get_column_alias(self.model_cls.Meta.pkname)
             kwargs[pk_name] = kwargs.pop("pk")
 
-        filter_clauses, select_related = self._populate_filter_clauses(**kwargs)
+        filter_clauses, select_related = self._populate_filter_clauses(
+            _own_only=_own_only, **kwargs
+        )
 
         return filter_clauses, select_related
 
     def _populate_filter_clauses(
-        self, **kwargs: Any
+        self, _own_only: bool, **kwargs: Any
     ) -> Tuple[List[FilterAction], List[str]]:
         """
         Iterates all clauses and extracts used operator and field from related
@@ -74,6 +174,7 @@ class QueryClause:
         :rtype: Tuple[List[sqlalchemy.sql.elements.TextClause], List[str]]
         """
         filter_clauses = self.filter_clauses
+        own_filter_clauses = []
         select_related = list(self._select_related)
 
         for key, value in kwargs.items():
@@ -84,12 +185,14 @@ class QueryClause:
                 select_related=select_related
             )
 
-            filter_clauses.append(filter_action)
+            own_filter_clauses.append(filter_action)
 
         self._register_complex_duplicates(select_related)
         filter_clauses = self._switch_filter_action_prefixes(
-            filter_clauses=filter_clauses
+            filter_clauses=filter_clauses + own_filter_clauses
         )
+        if _own_only:
+            return own_filter_clauses, select_related
         return filter_clauses, select_related
 
     def _register_complex_duplicates(self, select_related: List[str]) -> None:
@@ -150,11 +253,17 @@ class QueryClause:
         :return: list of actions with aliases changed if needed
         :rtype: List[FilterAction]
         """
-        manager = self.model_cls.Meta.alias_manager
+
         for action in filter_clauses:
-            new_alias = manager.resolve_relation_alias(
-                self.model_cls, action.related_str
-            )
-            if "__" in action.related_str and new_alias:
-                action.table_prefix = new_alias
+            if isinstance(action, FilterGroup):
+                for action2 in action._iter():
+                    self._verify_prefix_and_switch(action2)
+            else:
+                self._verify_prefix_and_switch(action)
         return filter_clauses
+
+    def _verify_prefix_and_switch(self, action: "FilterAction") -> None:
+        manager = self.model_cls.Meta.alias_manager
+        new_alias = manager.resolve_relation_alias(self.model_cls, action.related_str)
+        if "__" in action.related_str and new_alias:
+            action.table_prefix = new_alias

--- a/ormar/queryset/prefetch_query.py
+++ b/ormar/queryset/prefetch_query.py
@@ -266,7 +266,7 @@ class PrefetchQuery:
                 model_cls=clause_target, select_related=[], filter_clauses=[],
             )
             kwargs = {f"{filter_column}__in": ids}
-            filter_clauses, _ = qryclause.prepare_filter(**kwargs)
+            filter_clauses, _ = qryclause.prepare_filter(_own_only=False, **kwargs)
             return filter_clauses
         return []
 

--- a/ormar/queryset/query.py
+++ b/ormar/queryset/query.py
@@ -173,7 +173,7 @@ class Query:
             limit_qry
         )
         limit_qry = limit_qry.group_by(qry_text)
-        limit_qry = OrderQuery(sorted_orders=self.sorted_orders).apply(limit_qry)
+        # limit_qry = OrderQuery(sorted_orders=self.sorted_orders).apply(limit_qry)
         limit_qry = LimitQuery(limit_count=self.limit_count).apply(limit_qry)
         limit_qry = OffsetQuery(query_offset=self.query_offset).apply(limit_qry)
         limit_action = FilterAction(

--- a/ormar/queryset/query.py
+++ b/ormar/queryset/query.py
@@ -172,13 +172,13 @@ class Query:
         pk_alias = self.model_cls.get_column_alias(self.model_cls.Meta.pkname)
         pk_aliased_name = f"{self.table.name}.{pk_alias}"
         qry_text = sqlalchemy.text(f"{pk_aliased_name} as limit_column")
-        maxes = dict()
-        for order in list(self.sorted_orders.keys()):
-            if order is not None and order.get_field_name_text() != pk_aliased_name:
-                aliased_col = order.get_field_name_text()
-                maxes[aliased_col] = sqlalchemy.text(aliased_col)
+        # maxes = dict()
+        # for order in list(self.sorted_orders.keys()):
+        #     if order is not None and order.get_field_name_text() != pk_aliased_name:
+        #         aliased_col = order.get_field_name_text()
+        #         maxes[aliased_col] = sqlalchemy.text(aliased_col)
 
-        limit_qry = sqlalchemy.sql.select([qry_text]+list(maxes.values()))
+        limit_qry = sqlalchemy.sql.select([qry_text])
         limit_qry = limit_qry.select_from(self.select_from)
         limit_qry = self._apply_expression_modifiers(limit_qry)
         limit_qry = FilterQuery(filter_clauses=self.filter_clauses).apply(limit_qry)

--- a/ormar/queryset/query.py
+++ b/ormar/queryset/query.py
@@ -186,7 +186,6 @@ class Query:
                                 exclude=True).apply(
             limit_qry
         )
-        limit_qry = limit_qry.group_by(sqlalchemy.text(f"{pk_aliased_name}"))
         limit_qry = OrderQuery(sorted_orders=self.sorted_orders).apply(limit_qry)
         limit_qry = limit_qry.alias("inner_limit_query")
         outer_text = sqlalchemy.text(f"distinct limit_column")

--- a/ormar/queryset/query.py
+++ b/ormar/queryset/query.py
@@ -172,26 +172,31 @@ class Query:
         pk_alias = self.model_cls.get_column_alias(self.model_cls.Meta.pkname)
         pk_aliased_name = f"{self.table.name}.{pk_alias}"
         qry_text = sqlalchemy.text(f"{pk_aliased_name} as limit_column")
-        # maxes = dict()
-        # for order in list(self.sorted_orders.keys()):
-        #     if order is not None and order.get_field_name_text() != pk_aliased_name:
-        #         aliased_col = order.get_field_name_text()
-        #         maxes[aliased_col] = sqlalchemy.text(aliased_col)
+        maxes = dict()
+        for ind, order in enumerate(list(self.sorted_orders.keys())):
+            if order is not None and order.get_field_name_text() != pk_aliased_name:
+                aliased_col = order.get_field_name_text()
+                maxes[aliased_col] = sqlalchemy.text(f"{aliased_col} as col{ind}")
 
-        limit_qry = sqlalchemy.sql.select([qry_text])
+        limit_qry = sqlalchemy.sql.select([qry_text] + list(maxes.values()))
         limit_qry = limit_qry.select_from(self.select_from)
         limit_qry = self._apply_expression_modifiers(limit_qry)
         limit_qry = FilterQuery(filter_clauses=self.filter_clauses).apply(limit_qry)
         limit_qry = FilterQuery(filter_clauses=self.exclude_clauses,
-                                exclude=True).apply(limit_qry)
-        limit_qry = limit_qry.group_by(sqlalchemy.text(f"{pk_aliased_name}"))
+                                exclude=True).apply(
+            limit_qry
+        )
         limit_qry = OrderQuery(sorted_orders=self.sorted_orders).apply(limit_qry)
-        limit_qry = LimitQuery(limit_count=self.limit_count).apply(limit_qry)
-        limit_qry = OffsetQuery(query_offset=self.query_offset).apply(limit_qry)
-        limit_qry = limit_qry.alias("limit_query")
+        limit_qry = limit_qry.alias("inner_limit_query")
+        outer_text = sqlalchemy.text(f"distinct limit_column")
+        outer_qry = sqlalchemy.sql.select([outer_text])
+        outer_qry = outer_qry.select_from(limit_qry)
+        outer_qry = LimitQuery(limit_count=self.limit_count).apply(outer_qry)
+        outer_qry = OffsetQuery(query_offset=self.query_offset).apply(outer_qry)
+        outer_qry = outer_qry.alias("limit_query")
         on_clause = sqlalchemy.text(
             f"limit_query.limit_column={self.table.name}.{pk_alias}")
-        return limit_qry, on_clause
+        return outer_qry, on_clause
 
     def _apply_expression_modifiers(
             self, expr: sqlalchemy.sql.select

--- a/ormar/queryset/query.py
+++ b/ormar/queryset/query.py
@@ -171,12 +171,12 @@ class Query:
         """
         pk_alias = self.model_cls.get_column_alias(self.model_cls.Meta.pkname)
         pk_aliased_name = f"{self.table.name}.{pk_alias}"
-        qry_text = sqlalchemy.text(pk_aliased_name)
+        qry_text = sqlalchemy.text(f"{pk_aliased_name} as limit_column")
         maxes = dict()
         for order in list(self.sorted_orders.keys()):
             if order is not None and order.get_field_name_text() != pk_aliased_name:
-                maxes[order.get_field_name_text()] = sqlalchemy.text(
-                    f"max({order.get_field_name_text()})")
+                aliased_col = order.get_field_name_text()
+                maxes[aliased_col] = sqlalchemy.text(aliased_col)
 
         limit_qry = sqlalchemy.sql.select([qry_text]+list(maxes.values()))
         limit_qry = limit_qry.select_from(self.select_from)
@@ -186,14 +186,18 @@ class Query:
                                 exclude=True).apply(
             limit_qry
         )
-        limit_qry = limit_qry.group_by(qry_text)
+        limit_qry = limit_qry.group_by(sqlalchemy.text(f"{pk_aliased_name}"))
         limit_qry = OrderQuery(sorted_orders=self.sorted_orders).apply(limit_qry)
-        limit_qry = LimitQuery(limit_count=self.limit_count).apply(limit_qry)
-        limit_qry = OffsetQuery(query_offset=self.query_offset).apply(limit_qry)
-        limit_qry = limit_qry.alias("limit_query")
+        limit_qry = limit_qry.alias("inner_limit_query")
+        outer_text = sqlalchemy.text(f"distinct limit_column")
+        outer_qry = sqlalchemy.sql.select([outer_text])
+        outer_qry = outer_qry.select_from(limit_qry)
+        outer_qry = LimitQuery(limit_count=self.limit_count).apply(outer_qry)
+        outer_qry = OffsetQuery(query_offset=self.query_offset).apply(outer_qry)
+        outer_qry = outer_qry.alias("limit_query")
         on_clause = sqlalchemy.text(
-            f"limit_query.{pk_alias}={self.table.name}.{pk_alias}")
-        return limit_qry, on_clause
+            f"limit_query.limit_column={self.table.name}.{pk_alias}")
+        return outer_qry, on_clause
 
     def _apply_expression_modifiers(
             self, expr: sqlalchemy.sql.select

--- a/ormar/queryset/query.py
+++ b/ormar/queryset/query.py
@@ -108,10 +108,7 @@ class Query:
             "", self.table, self_related_fields
         )
         self.apply_order_bys_for_primary_model()
-        if self._pagination_query_required():
-            self.select_from = self._build_pagination_subquery()
-        else:
-            self.select_from = self.table
+        self.select_from = self.table
 
         related_models = group_related_list(self._select_related)
 
@@ -139,6 +136,9 @@ class Query:
                 self.sorted_orders,
             ) = sql_join.build_join()
 
+        if self._pagination_query_required():
+            self._build_pagination_condition()
+
         expr = sqlalchemy.sql.select(self.columns)
         expr = expr.select_from(self.select_from)
 
@@ -149,7 +149,7 @@ class Query:
 
         return expr
 
-    def _build_pagination_subquery(self) -> sqlalchemy.sql.select:
+    def _build_pagination_condition(self) -> None:
         """
         In order to apply limit and offset on main table in join only
         (otherwise you can get only partially constructed main model
@@ -160,32 +160,20 @@ class Query:
         and query has select_related applied. Otherwise we can limit/offset normally
         at the end of whole query.
 
-        :return: constructed subquery on main table with limit, offset and order applied
-        :rtype: sqlalchemy.sql.select
+        The condition is added to filters to filter out desired number of main model
+        primary key values. Whole query is used to determine the values.
         """
-        expr = sqlalchemy.sql.select(self.model_cls.Meta.table.columns)
-        expr = LimitQuery(limit_count=self.limit_count).apply(expr)
-        expr = OffsetQuery(query_offset=self.query_offset).apply(expr)
-        filters_to_use = [
-            filter_clause
-            for filter_clause in self.filter_clauses
-            if filter_clause.is_source_model_filter
-        ]
-        excludes_to_use = [
-            filter_clause
-            for filter_clause in self.exclude_clauses
-            if filter_clause.is_source_model_filter
-        ]
-        sorts_to_use = {
-            k: v for k, v in self.sorted_orders.items() if k.is_source_model_order
-        }
-        expr = FilterQuery(filter_clauses=filters_to_use).apply(expr)
-        expr = FilterQuery(filter_clauses=excludes_to_use, exclude=True).apply(expr)
-        expr = OrderQuery(sorted_orders=sorts_to_use).apply(expr)
-        expr = expr.alias(f"{self.table}")
-        self.filter_clauses = list(set(self.filter_clauses) - set(filters_to_use))
-        self.exclude_clauses = list(set(self.exclude_clauses) - set(excludes_to_use))
-        return expr
+        pk_alias = self.model_cls.get_column_alias(self.model_cls.Meta.pkname)
+        qry_text = sqlalchemy.text(f"distinct {self.table.name}.{pk_alias}")
+        limit_qry = sqlalchemy.sql.select([qry_text])
+        limit_qry = limit_qry.select_from(self.select_from)
+        limit_qry = self._apply_expression_modifiers(limit_qry)
+        limit_qry = LimitQuery(limit_count=self.limit_count).apply(limit_qry)
+        limit_qry = OffsetQuery(query_offset=self.query_offset).apply(limit_qry)
+        limit_action = FilterAction(
+            filter_str=f"{pk_alias}__in", value=limit_qry, model_cls=self.model_cls
+        )
+        self.filter_clauses.append(limit_action)
 
     def _apply_expression_modifiers(
         self, expr: sqlalchemy.sql.select

--- a/ormar/queryset/query.py
+++ b/ormar/queryset/query.py
@@ -18,16 +18,16 @@ if TYPE_CHECKING:  # pragma no cover
 
 class Query:
     def __init__(  # noqa CFQ002
-            self,
-            model_cls: Type["Model"],
-            filter_clauses: List[FilterAction],
-            exclude_clauses: List[FilterAction],
-            select_related: List,
-            limit_count: Optional[int],
-            offset: Optional[int],
-            excludable: "ExcludableItems",
-            order_bys: Optional[List["OrderAction"]],
-            limit_raw_sql: bool,
+        self,
+        model_cls: Type["Model"],
+        filter_clauses: List[FilterAction],
+        exclude_clauses: List[FilterAction],
+        select_related: List,
+        limit_count: Optional[int],
+        offset: Optional[int],
+        excludable: "ExcludableItems",
+        order_bys: Optional[List["OrderAction"]],
+        limit_raw_sql: bool,
     ) -> None:
         self.query_offset = offset
         self.limit_count = limit_count
@@ -153,9 +153,10 @@ class Query:
         return expr
 
     def _build_pagination_condition(
-            self
+        self,
     ) -> Tuple[
-        sqlalchemy.sql.expression.TextClause, sqlalchemy.sql.expression.TextClause]:
+        sqlalchemy.sql.expression.TextClause, sqlalchemy.sql.expression.TextClause
+    ]:
         """
         In order to apply limit and offset on main table in join only
         (otherwise you can get only partially constructed main model
@@ -183,10 +184,9 @@ class Query:
         limit_qry = sqlalchemy.sql.select([qry_text])
         limit_qry = limit_qry.select_from(self.select_from)
         limit_qry = FilterQuery(filter_clauses=self.filter_clauses).apply(limit_qry)
-        limit_qry = FilterQuery(filter_clauses=self.exclude_clauses,
-                                exclude=True).apply(
-            limit_qry
-        )
+        limit_qry = FilterQuery(
+            filter_clauses=self.exclude_clauses, exclude=True
+        ).apply(limit_qry)
         limit_qry = limit_qry.group_by(qry_text)
         for order_by in maxes.values():
             limit_qry = limit_qry.order_by(order_by)
@@ -194,11 +194,12 @@ class Query:
         limit_qry = OffsetQuery(query_offset=self.query_offset).apply(limit_qry)
         limit_qry = limit_qry.alias("limit_query")
         on_clause = sqlalchemy.text(
-            f"limit_query.{pk_alias}={self.table.name}.{pk_alias}")
+            f"limit_query.{pk_alias}={self.table.name}.{pk_alias}"
+        )
         return limit_qry, on_clause
 
     def _apply_expression_modifiers(
-            self, expr: sqlalchemy.sql.select
+        self, expr: sqlalchemy.sql.select
     ) -> sqlalchemy.sql.select:
         """
         Receives the select query (might be join) and applies:

--- a/ormar/queryset/query.py
+++ b/ormar/queryset/query.py
@@ -171,32 +171,31 @@ class Query:
         """
         pk_alias = self.model_cls.get_column_alias(self.model_cls.Meta.pkname)
         pk_aliased_name = f"{self.table.name}.{pk_alias}"
-        qry_text = sqlalchemy.text(f"{pk_aliased_name} as limit_column")
-        maxes = dict()
-        for ind, order in enumerate(list(self.sorted_orders.keys())):
+        qry_text = sqlalchemy.text(f"{pk_aliased_name}")
+        maxes = OrderedDict()
+        for order in list(self.sorted_orders.keys()):
             if order is not None and order.get_field_name_text() != pk_aliased_name:
                 aliased_col = order.get_field_name_text()
-                maxes[aliased_col] = sqlalchemy.text(f"{aliased_col} as col{ind}")
+                maxes[aliased_col] = order.get_min_or_max()
+            elif order.get_field_name_text() == pk_aliased_name:
+                maxes[pk_aliased_name] = order.get_text_clause()
 
-        limit_qry = sqlalchemy.sql.select([qry_text] + list(maxes.values()))
+        limit_qry = sqlalchemy.sql.select([qry_text])
         limit_qry = limit_qry.select_from(self.select_from)
-        limit_qry = self._apply_expression_modifiers(limit_qry)
         limit_qry = FilterQuery(filter_clauses=self.filter_clauses).apply(limit_qry)
         limit_qry = FilterQuery(filter_clauses=self.exclude_clauses,
                                 exclude=True).apply(
             limit_qry
         )
-        limit_qry = OrderQuery(sorted_orders=self.sorted_orders).apply(limit_qry)
-        limit_qry = limit_qry.alias("inner_limit_query")
-        outer_text = sqlalchemy.text(f"distinct limit_column")
-        outer_qry = sqlalchemy.sql.select([outer_text])
-        outer_qry = outer_qry.select_from(limit_qry)
-        outer_qry = LimitQuery(limit_count=self.limit_count).apply(outer_qry)
-        outer_qry = OffsetQuery(query_offset=self.query_offset).apply(outer_qry)
-        outer_qry = outer_qry.alias("limit_query")
+        limit_qry = limit_qry.group_by(qry_text)
+        for order_by in maxes.values():
+            limit_qry = limit_qry.order_by(order_by)
+        limit_qry = LimitQuery(limit_count=self.limit_count).apply(limit_qry)
+        limit_qry = OffsetQuery(query_offset=self.query_offset).apply(limit_qry)
+        limit_qry = limit_qry.alias("limit_query")
         on_clause = sqlalchemy.text(
-            f"limit_query.limit_column={self.table.name}.{pk_alias}")
-        return outer_qry, on_clause
+            f"limit_query.{pk_alias}={self.table.name}.{pk_alias}")
+        return limit_qry, on_clause
 
     def _apply_expression_modifiers(
             self, expr: sqlalchemy.sql.select

--- a/ormar/queryset/queryset.py
+++ b/ormar/queryset/queryset.py
@@ -281,7 +281,7 @@ class QuerySet:
             limit_raw_sql=self.limit_sql_raw,
         )
         exp = qry.build_select_expression()
-        # print("\n", exp.compile(compile_kwargs={"literal_binds": True}))
+        print("\n", exp.compile(compile_kwargs={"literal_binds": True}))
         return exp
 
     def filter(  # noqa: A003

--- a/ormar/queryset/queryset.py
+++ b/ormar/queryset/queryset.py
@@ -281,7 +281,7 @@ class QuerySet:
             limit_raw_sql=self.limit_sql_raw,
         )
         exp = qry.build_select_expression()
-        print("\n", exp.compile(compile_kwargs={"literal_binds": True}))
+        # print("\n", exp.compile(compile_kwargs={"literal_binds": True}))
         return exp
 
     def filter(  # noqa: A003

--- a/ormar/relations/querysetproxy.py
+++ b/ormar/relations/querysetproxy.py
@@ -386,6 +386,8 @@ class QuerysetProxy:
         *  contains - like `album__name__contains='Mal'` (sql like)
         *  icontains - like `album__name__icontains='mal'` (sql like case insensitive)
         *  in - like `album__name__in=['Malibu', 'Barclay']` (sql in)
+        *  isnull - like `album__name__isnull=True` (sql is null)
+           (isnotnull `album__name__isnull=False` (sql is not null))
         *  gt - like `position__gt=3` (sql >)
         *  gte - like `position__gte=3` (sql >=)
         *  lt - like `position__lt=3` (sql <)

--- a/tests/test_filter_groups.py
+++ b/tests/test_filter_groups.py
@@ -1,0 +1,149 @@
+from typing import Optional
+
+import databases
+import sqlalchemy
+
+import ormar
+from tests.settings import DATABASE_URL
+
+database = databases.Database(DATABASE_URL)
+metadata = sqlalchemy.MetaData()
+
+
+class BaseMeta(ormar.ModelMeta):
+    metadata = metadata
+    database = database
+
+
+class Author(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "authors"
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+
+
+class Book(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "books"
+
+    id: int = ormar.Integer(primary_key=True)
+    author: Optional[Author] = ormar.ForeignKey(Author)
+    title: str = ormar.String(max_length=100)
+    year: int = ormar.Integer(nullable=True)
+
+
+def test_or_group():
+    result = ormar.or_(name="aa", books__title="bb")
+    result.resolve(model_cls=Author)
+    assert len(result.actions) == 2
+    assert result.actions[0].target_model == Author
+    assert result.actions[1].target_model == Book
+    assert (
+        str(result.get_text_clause()) == f"( authors.name = 'aa' OR "
+        f"{result.actions[1].table_prefix}"
+        f"_books.title = 'bb' )"
+    )
+    assert not result.is_source_model_filter
+
+
+def test_and_group():
+    result = ormar.and_(name="aa", books__title="bb")
+    result.resolve(model_cls=Author)
+    assert len(result.actions) == 2
+    assert result.actions[0].target_model == Author
+    assert result.actions[1].target_model == Book
+    assert (
+        str(result.get_text_clause()) == f"( authors.name = 'aa' AND "
+        f"{result.actions[1].table_prefix}"
+        f"_books.title = 'bb' )"
+    )
+    assert not result.is_source_model_filter
+
+
+def test_nested_and():
+    result = ormar.and_(
+        ormar.or_(name="aa", books__title="bb"), ormar.or_(name="cc", books__title="dd")
+    )
+    result.resolve(model_cls=Author)
+    assert len(result.actions) == 0
+    assert len(result._nested_groups) == 2
+    book_prefix = result._nested_groups[0].actions[1].table_prefix
+    assert (
+        str(result.get_text_clause()) == f"( ( authors.name = 'aa' OR "
+        f"{book_prefix}"
+        f"_books.title = 'bb' ) AND "
+        f"( authors.name = 'cc' OR "
+        f"{book_prefix}"
+        f"_books.title = 'dd' ) )"
+    )
+    assert not result.is_source_model_filter
+
+
+def test_nested_group_and_action():
+    result = ormar.and_(ormar.or_(name="aa", books__title="bb"), books__title="dd")
+    result.resolve(model_cls=Author)
+    assert len(result.actions) == 1
+    assert len(result._nested_groups) == 1
+    book_prefix = result._nested_groups[0].actions[1].table_prefix
+    assert (
+        str(result.get_text_clause()) == f"( ( authors.name = 'aa' OR "
+        f"{book_prefix}"
+        f"_books.title = 'bb' ) AND "
+        f"{book_prefix}"
+        f"_books.title = 'dd' )"
+    )
+    assert not result.is_source_model_filter
+
+
+def test_deeply_nested_or():
+    result = ormar.or_(
+        ormar.and_(
+            ormar.or_(name="aa", books__title="bb"),
+            ormar.or_(name="cc", books__title="dd"),
+        ),
+        ormar.and_(
+            ormar.or_(books__year__lt=1900, books__title="11"),
+            ormar.or_(books__year__gt="xx", books__title="22"),
+        ),
+    )
+    result.resolve(model_cls=Author)
+    assert len(result.actions) == 0
+    assert len(result._nested_groups) == 2
+    assert len(result._nested_groups[0]._nested_groups) == 2
+    book_prefix = result._nested_groups[0]._nested_groups[0].actions[1].table_prefix
+    result_qry = str(result.get_text_clause())
+    expected_qry = (
+        f"( ( ( authors.name = 'aa' OR {book_prefix}_books.title = 'bb' ) AND "
+        f"( authors.name = 'cc' OR {book_prefix}_books.title = 'dd' ) ) "
+        f"OR ( ( {book_prefix}_books.year < 1900 OR {book_prefix}_books.title = '11' ) AND "
+        f"( {book_prefix}_books.year > 'xx' OR {book_prefix}_books.title = '22' ) ) )"
+    )
+    assert result_qry.replace("\n", "") == expected_qry.replace("\n", "")
+    assert not result.is_source_model_filter
+
+
+def test_one_model_group():
+    result = ormar.and_(year__gt=1900, title="bb")
+    result.resolve(model_cls=Book)
+    assert len(result.actions) == 2
+    assert len(result._nested_groups) == 0
+    assert result.is_source_model_filter
+
+
+def test_one_model_nested_group():
+    result = ormar.and_(
+        ormar.or_(year__gt=1900, title="bb"), ormar.or_(year__lt=1800, title="aa")
+    )
+    result.resolve(model_cls=Book)
+    assert len(result.actions) == 0
+    assert len(result._nested_groups) == 2
+    assert result.is_source_model_filter
+
+
+def test_one_model_with_group():
+    result = ormar.or_(ormar.and_(year__gt=1900, title="bb"), title="uu")
+    result.resolve(model_cls=Book)
+    assert len(result.actions) == 1
+    assert len(result._nested_groups) == 1
+    assert result.is_source_model_filter

--- a/tests/test_filter_groups.py
+++ b/tests/test_filter_groups.py
@@ -44,7 +44,6 @@ def test_or_group():
         f"{result.actions[1].table_prefix}"
         f"_books.title = 'bb' )"
     )
-    assert not result.is_source_model_filter
 
 
 def test_and_group():
@@ -58,7 +57,6 @@ def test_and_group():
         f"{result.actions[1].table_prefix}"
         f"_books.title = 'bb' )"
     )
-    assert not result.is_source_model_filter
 
 
 def test_nested_and():
@@ -77,7 +75,6 @@ def test_nested_and():
         f"{book_prefix}"
         f"_books.title = 'dd' ) )"
     )
-    assert not result.is_source_model_filter
 
 
 def test_nested_group_and_action():
@@ -93,7 +90,6 @@ def test_nested_group_and_action():
         f"{book_prefix}"
         f"_books.title = 'dd' )"
     )
-    assert not result.is_source_model_filter
 
 
 def test_deeply_nested_or():
@@ -120,7 +116,6 @@ def test_deeply_nested_or():
         f"( {book_prefix}_books.year > 'xx' OR {book_prefix}_books.title = '22' ) ) )"
     )
     assert result_qry.replace("\n", "") == expected_qry.replace("\n", "")
-    assert not result.is_source_model_filter
 
 
 def test_one_model_group():
@@ -128,7 +123,6 @@ def test_one_model_group():
     result.resolve(model_cls=Book)
     assert len(result.actions) == 2
     assert len(result._nested_groups) == 0
-    assert result.is_source_model_filter
 
 
 def test_one_model_nested_group():
@@ -138,7 +132,6 @@ def test_one_model_nested_group():
     result.resolve(model_cls=Book)
     assert len(result.actions) == 0
     assert len(result._nested_groups) == 2
-    assert result.is_source_model_filter
 
 
 def test_one_model_with_group():
@@ -146,4 +139,3 @@ def test_one_model_with_group():
     result.resolve(model_cls=Book)
     assert len(result.actions) == 1
     assert len(result._nested_groups) == 1
-    assert result.is_source_model_filter

--- a/tests/test_isnull_filter.py
+++ b/tests/test_isnull_filter.py
@@ -1,0 +1,76 @@
+from typing import Optional
+
+import databases
+import pytest
+import sqlalchemy
+
+import ormar
+from tests.settings import DATABASE_URL
+
+database = databases.Database(DATABASE_URL)
+metadata = sqlalchemy.MetaData()
+
+
+class BaseMeta(ormar.ModelMeta):
+    metadata = metadata
+    database = database
+
+
+class Author(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "authors"
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+
+
+class Book(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "books"
+
+    id: int = ormar.Integer(primary_key=True)
+    author: Optional[Author] = ormar.ForeignKey(Author)
+    title: str = ormar.String(max_length=100)
+    year: int = ormar.Integer(nullable=True)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def create_test_database():
+    engine = sqlalchemy.create_engine(DATABASE_URL)
+    metadata.drop_all(engine)
+    metadata.create_all(engine)
+    yield
+    metadata.drop_all(engine)
+
+
+@pytest.mark.asyncio
+async def test_is_null():
+    async with database:
+        tolkien = await Author.objects.create(name="J.R.R. Tolkien")
+        await Book.objects.create(author=tolkien, title="The Hobbit")
+        await Book.objects.create(
+            author=tolkien, title="The Lord of the Rings", year=1955
+        )
+        await Book.objects.create(author=tolkien, title="The Silmarillion", year=1977)
+
+        books = await Book.objects.all(year__isnull=True)
+        assert len(books) == 1
+        assert books[0].year is None
+        assert books[0].title == "The Hobbit"
+
+        books = await Book.objects.all(year__isnull=False)
+        assert len(books) == 2
+
+        tolkien = await Author.objects.select_related("books").get(
+            books__year__isnull=True
+        )
+        assert len(tolkien.books) == 1
+        assert tolkien.books[0].year is None
+        assert tolkien.books[0].title == "The Hobbit"
+
+        tolkien = await Author.objects.select_related("books").get(
+            books__year__isnull=False
+        )
+        assert len(tolkien.books) == 2
+        assert tolkien.books[0].year == 1955
+        assert tolkien.books[0].title == "The Lord of the Rings"

--- a/tests/test_or_filters.py
+++ b/tests/test_or_filters.py
@@ -153,8 +153,7 @@ async def test_or_filters():
         assert books[0].title == "The Witcher"
 
         with pytest.raises(QueryDefinitionError):
-            await Book.objects.select_related("author").filter('wrong').all()
-
+            await Book.objects.select_related("author").filter("wrong").all()
 
 
 # TODO: Check / modify

--- a/tests/test_or_filters.py
+++ b/tests/test_or_filters.py
@@ -83,6 +83,21 @@ async def test_or_filters():
         books = (
             await Book.objects.select_related("author")
             .filter(
+                ormar.and_(
+                    ormar.or_(year__gt=1960, year__lt=1940),
+                    author__name="J.R.R. Tolkien",
+                )
+            )
+            .all()
+        )
+
+        assert len(books) == 2
+        assert books[0].title == "The Hobbit"
+        assert books[1].title == "The Silmarillion"
+
+        books = (
+            await Book.objects.select_related("author")
+            .filter(
                 ormar.or_(
                     ormar.and_(year__gt=1960, author__name="J.R.R. Tolkien"),
                     ormar.and_(year__lt=2000, author__name="Andrzej Sapkowski"),
@@ -108,6 +123,23 @@ async def test_or_filters():
         )
         assert len(books) == 3
         assert not any([x.title in ["The Silmarillion", "The Witcher"] for x in books])
+
+        books = (
+            await Book.objects.select_related("author")
+            .filter(
+                ormar.or_(
+                    ormar.and_(year__gt=1960, author__name="J.R.R. Tolkien"),
+                    ormar.and_(year__lt=2000, author__name="Andrzej Sapkowski"),
+                    title__icontains="hobbit",
+                )
+            )
+            .filter(title__startswith="The")
+            .all()
+        )
+        assert len(books) == 3
+        assert not any(
+            [x.title in ["The Tower of Fools", "The Lord of the Rings"] for x in books]
+        )
 
         books = (
             await Book.objects.select_related("author")
@@ -163,5 +195,6 @@ async def test_or_filters():
 # fix limit -> change to where subquery to extract number of distinct pk values (V)
 # finish docstrings (V)
 # fix types for FilterAction and FilterGroup (X)
+# add docs (V)
 
-# add docs
+# fix querysetproxy

--- a/tests/test_or_filters.py
+++ b/tests/test_or_filters.py
@@ -1,0 +1,118 @@
+from typing import Optional
+
+import databases
+import pytest
+import sqlalchemy
+
+import ormar
+from tests.settings import DATABASE_URL
+
+database = databases.Database(DATABASE_URL)
+metadata = sqlalchemy.MetaData()
+
+
+class BaseMeta(ormar.ModelMeta):
+    metadata = metadata
+    database = database
+
+
+class Author(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "authors"
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+
+
+class Book(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "books"
+
+    id: int = ormar.Integer(primary_key=True)
+    author: Optional[Author] = ormar.ForeignKey(Author)
+    title: str = ormar.String(max_length=100)
+    year: int = ormar.Integer(nullable=True)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def create_test_database():
+    engine = sqlalchemy.create_engine(DATABASE_URL)
+    metadata.drop_all(engine)
+    metadata.create_all(engine)
+    yield
+    metadata.drop_all(engine)
+
+
+@pytest.mark.asyncio
+async def test_or_filters():
+    async with database:
+        tolkien = await Author(name="J.R.R. Tolkien").save()
+        await Book(author=tolkien, title="The Hobbit", year=1933).save()
+        await Book(author=tolkien, title="The Lord of the Rings", year=1955).save()
+        await Book(author=tolkien, title="The Silmarillion", year=1977).save()
+        sapkowski = await Author(name="Andrzej Sapkowski").save()
+        await Book(author=sapkowski, title="The Witcher", year=1990).save()
+        await Book(author=sapkowski, title="The Tower of Fools", year=2002).save()
+
+        books = (
+            await Book.objects.select_related("author")
+            .filter(ormar.or_(author__name="J.R.R. Tolkien", year__gt=1970))
+            .all()
+        )
+        assert len(books) == 5
+
+        books = (
+            await Book.objects.select_related("author")
+            .filter(ormar.or_(author__name="J.R.R. Tolkien", year__lt=1995))
+            .all()
+        )
+        assert len(books) == 4
+        assert not any([x.title == "The Tower of Fools" for x in books])
+
+        books = (
+            await Book.objects.select_related("author")
+            .filter(ormar.or_(year__gt=1960, year__lt=1940))
+            .filter(author__name="J.R.R. Tolkien")
+            .all()
+        )
+        assert len(books) == 2
+        assert books[0].title == "The Hobbit"
+        assert books[1].title == "The Silmarillion"
+
+        books = (
+            await Book.objects.select_related("author")
+            .filter(
+                ormar.or_(
+                    ormar.and_(year__gt=1960, author__name="J.R.R. Tolkien"),
+                    ormar.and_(year__lt=2000, author__name="Andrzej Sapkowski"),
+                )
+            )
+            .filter(title__startswith="The")
+            .all()
+        )
+        assert len(books) == 2
+        assert books[0].title == "The Silmarillion"
+        assert books[1].title == "The Witcher"
+
+        books = (
+            await Book.objects.select_related("author")
+            .exclude(
+                ormar.or_(
+                    ormar.and_(year__gt=1960, author__name="J.R.R. Tolkien"),
+                    ormar.and_(year__lt=2000, author__name="Andrzej Sapkowski"),
+                )
+            )
+            .filter(title__startswith="The")
+            .all()
+        )
+        assert len(books) == 3
+        assert not any([x.title in ["The Silmarillion", "The Witcher"] for x in books])
+
+
+# TODO: Check / modify
+# process and and or into filter groups (V)
+# check exclude queries working (V)
+
+# when limit and no sql do not allow main model and other models
+# check complex prefixes properly resolved
+# fix types for FilterAction and FilterGroup (?)

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -132,6 +132,11 @@ async def test_sort_order_on_main_model():
         assert songs[1].name == "Song 2"
         assert songs[2].name == "Song 3"
 
+        songs = await Song.objects.order_by("name").limit(2).all()
+        assert len(songs) == 2
+        assert songs[0].name == "Song 1"
+        assert songs[1].name == "Song 2"
+
         await Song.objects.create(name="Song 4", sort_order=1)
 
         songs = await Song.objects.order_by(["sort_order", "name"]).all()
@@ -169,27 +174,27 @@ async def test_sort_order_on_related_model():
 
         owner = (
             await Owner.objects.select_related("toys")
-            .order_by("toys__name")
-            .filter(name="Zeus")
-            .get()
+                .order_by("toys__name")
+                .filter(name="Zeus")
+                .get()
         )
         assert owner.toys[0].name == "Toy 1"
         assert owner.toys[1].name == "Toy 4"
 
         owner = (
             await Owner.objects.select_related("toys")
-            .order_by("-toys__name")
-            .filter(name="Zeus")
-            .get()
+                .order_by("-toys__name")
+                .filter(name="Zeus")
+                .get()
         )
         assert owner.toys[0].name == "Toy 4"
         assert owner.toys[1].name == "Toy 1"
 
         owners = (
             await Owner.objects.select_related("toys")
-            .order_by("-toys__name")
-            .filter(name__in=["Zeus", "Hermes"])
-            .all()
+                .order_by("-toys__name")
+                .filter(name__in=["Zeus", "Hermes"])
+                .all()
         )
         assert owners[0].toys[0].name == "Toy 6"
         assert owners[0].toys[1].name == "Toy 5"
@@ -203,9 +208,9 @@ async def test_sort_order_on_related_model():
 
         owners = (
             await Owner.objects.select_related("toys")
-            .order_by("-toys__name")
-            .filter(name__in=["Zeus", "Hermes"])
-            .all()
+                .order_by("-toys__name")
+                .filter(name__in=["Zeus", "Hermes"])
+                .all()
         )
         assert owners[0].toys[0].name == "Toy 7"
         assert owners[0].toys[1].name == "Toy 4"
@@ -215,6 +220,12 @@ async def test_sort_order_on_related_model():
         assert owners[1].toys[0].name == "Toy 6"
         assert owners[1].toys[1].name == "Toy 5"
         assert owners[1].name == "Hermes"
+
+        toys = await Toy.objects.select_related('owner').order_by('owner__name').limit(
+            2).all()
+        assert len(toys) == 2
+        assert toys[0].name == 'Toy 2'
+        assert toys[1].name == 'Toy 3'
 
 
 @pytest.mark.asyncio
@@ -245,9 +256,9 @@ async def test_sort_order_on_many_to_many():
 
         user = (
             await User.objects.select_related("cars")
-            .filter(name="Mark")
-            .order_by("cars__name")
-            .get()
+                .filter(name="Mark")
+                .order_by("cars__name")
+                .get()
         )
         assert user.cars[0].name == "Buggy"
         assert user.cars[1].name == "Ferrari"
@@ -256,9 +267,9 @@ async def test_sort_order_on_many_to_many():
 
         user = (
             await User.objects.select_related("cars")
-            .filter(name="Mark")
-            .order_by("-cars__name")
-            .get()
+                .filter(name="Mark")
+                .order_by("-cars__name")
+                .get()
         )
         assert user.cars[3].name == "Buggy"
         assert user.cars[2].name == "Ferrari"
@@ -274,8 +285,8 @@ async def test_sort_order_on_many_to_many():
 
         users = (
             await User.objects.select_related(["cars__factory"])
-            .order_by(["-cars__factory__name", "cars__name"])
-            .all()
+                .order_by(["-cars__factory__name", "cars__name"])
+                .all()
         )
 
         assert users[0].name == "Julie"
@@ -321,8 +332,8 @@ async def test_sort_order_with_aliases():
 
         aliases = (
             await AliasTest.objects.select_related("nested")
-            .order_by("-nested__name")
-            .all()
+                .order_by("-nested__name")
+                .all()
         )
         assert aliases[0].nested.name == "Try4"
         assert aliases[1].nested.name == "Try3"

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -221,7 +221,8 @@ async def test_sort_order_on_related_model():
         assert owners[1].toys[1].name == "Toy 5"
         assert owners[1].name == "Hermes"
 
-        toys = await Toy.objects.select_related('owner').order_by('owner__name').limit(
+        toys = await Toy.objects.select_related('owner').order_by(
+            ['owner__name', 'name']).limit(
             2).all()
         assert len(toys) == 2
         assert toys[0].name == 'Toy 2'

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -174,27 +174,27 @@ async def test_sort_order_on_related_model():
 
         owner = (
             await Owner.objects.select_related("toys")
-                .order_by("toys__name")
-                .filter(name="Zeus")
-                .get()
+            .order_by("toys__name")
+            .filter(name="Zeus")
+            .get()
         )
         assert owner.toys[0].name == "Toy 1"
         assert owner.toys[1].name == "Toy 4"
 
         owner = (
             await Owner.objects.select_related("toys")
-                .order_by("-toys__name")
-                .filter(name="Zeus")
-                .get()
+            .order_by("-toys__name")
+            .filter(name="Zeus")
+            .get()
         )
         assert owner.toys[0].name == "Toy 4"
         assert owner.toys[1].name == "Toy 1"
 
         owners = (
             await Owner.objects.select_related("toys")
-                .order_by("-toys__name")
-                .filter(name__in=["Zeus", "Hermes"])
-                .all()
+            .order_by("-toys__name")
+            .filter(name__in=["Zeus", "Hermes"])
+            .all()
         )
         assert owners[0].toys[0].name == "Toy 6"
         assert owners[0].toys[1].name == "Toy 5"
@@ -208,9 +208,9 @@ async def test_sort_order_on_related_model():
 
         owners = (
             await Owner.objects.select_related("toys")
-                .order_by("-toys__name")
-                .filter(name__in=["Zeus", "Hermes"])
-                .all()
+            .order_by("-toys__name")
+            .filter(name__in=["Zeus", "Hermes"])
+            .all()
         )
         assert owners[0].toys[0].name == "Toy 7"
         assert owners[0].toys[1].name == "Toy 4"
@@ -221,12 +221,15 @@ async def test_sort_order_on_related_model():
         assert owners[1].toys[1].name == "Toy 5"
         assert owners[1].name == "Hermes"
 
-        toys = await Toy.objects.select_related('owner').order_by(
-            ['owner__name', 'name']).limit(
-            2).all()
+        toys = (
+            await Toy.objects.select_related("owner")
+            .order_by(["owner__name", "name"])
+            .limit(2)
+            .all()
+        )
         assert len(toys) == 2
-        assert toys[0].name == 'Toy 2'
-        assert toys[1].name == 'Toy 3'
+        assert toys[0].name == "Toy 2"
+        assert toys[1].name == "Toy 3"
 
 
 @pytest.mark.asyncio
@@ -257,9 +260,9 @@ async def test_sort_order_on_many_to_many():
 
         user = (
             await User.objects.select_related("cars")
-                .filter(name="Mark")
-                .order_by("cars__name")
-                .get()
+            .filter(name="Mark")
+            .order_by("cars__name")
+            .get()
         )
         assert user.cars[0].name == "Buggy"
         assert user.cars[1].name == "Ferrari"
@@ -268,9 +271,9 @@ async def test_sort_order_on_many_to_many():
 
         user = (
             await User.objects.select_related("cars")
-                .filter(name="Mark")
-                .order_by("-cars__name")
-                .get()
+            .filter(name="Mark")
+            .order_by("-cars__name")
+            .get()
         )
         assert user.cars[3].name == "Buggy"
         assert user.cars[2].name == "Ferrari"
@@ -286,8 +289,8 @@ async def test_sort_order_on_many_to_many():
 
         users = (
             await User.objects.select_related(["cars__factory"])
-                .order_by(["-cars__factory__name", "cars__name"])
-                .all()
+            .order_by(["-cars__factory__name", "cars__name"])
+            .all()
         )
 
         assert users[0].name == "Julie"
@@ -333,8 +336,8 @@ async def test_sort_order_with_aliases():
 
         aliases = (
             await AliasTest.objects.select_related("nested")
-                .order_by("-nested__name")
-                .all()
+            .order_by("-nested__name")
+            .all()
         )
         assert aliases[0].nested.name == "Try4"
         assert aliases[1].nested.name == "Try3"


### PR DESCRIPTION
# 0.9.7

## Features
* Add `isnull` operator to filter and exclude methods. [Issue #114 ]
    ```python
    album__name__isnull=True #(sql: album.name is null)
    album__name__isnull=False #(sql: album.name is not null))
    ```
* Add `ormar.or_` and `ormar.and_` functions that can be used to compose
  complex queries with nested conditions. [Issue #116 ]
  Sample query:
  ```python
  books = (
      await Book.objects.select_related("author")
      .filter(
          ormar.and_(
              ormar.or_(year__gt=1960, year__lt=1940),
              author__name="J.R.R. Tolkien",
          )
      )
      .all()
  )
  ```
  Check the updated docs in Queries -> Filtering and sorting -> Complex filters
