### PR TITLE
One sided relations and more powerful save_related

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,34 @@ since they actually have to create and connect to database in most of the tests.
 
 Yet remember that those are - well - tests and not all solutions are suitable to be used in real life applications.
 
+### Part of the `fastapi` ecosystem
+
+As part of the fastapi ecosystem `ormar` is supported in libraries that somehow work with databases.
+
+As of now `ormar` is supported by:
+
+*  [`fastapi-users`](https://github.com/frankie567/fastapi-users)
+*  [`fastapi-crudrouter`](https://github.com/awtkns/fastapi-crudrouter)
+*  [`fastapi-pagination`](https://github.com/uriyyo/fastapi-pagination)
+
+If you maintain or use different library and would like it to support `ormar` let us know how we can help.
+
 ### Dependencies
 
 Ormar is built with:
 
-  * [`SQLAlchemy core`][sqlalchemy-core] for query building.
+  * [`sqlalchemy core`][sqlalchemy-core] for query building.
   * [`databases`][databases] for cross-database async support.
   * [`pydantic`][pydantic] for data validation.
   * `typing_extensions` for python 3.6 - 3.7
+
+### Migrating from `sqlalchemy`
+
+If you currently use `sqlalchemy` and would like to switch to `ormar` check out the auto-translation
+tool that can help you with translating existing sqlalchemy orm models so you do not have to do it manually.
+
+**Beta** versions available at github: [`sqlalchemy-to-ormar`](https://github.com/collerek/sqlalchemy-to-ormar)
+or simply `pip install sqlalchemy-to-ormar`
 
 ### Migrations & Database creation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,14 +47,34 @@ since they actually have to create and connect to database in most of the tests.
 
 Yet remember that those are - well - tests and not all solutions are suitable to be used in real life applications.
 
+### Part of the `fastapi` ecosystem
+
+As part of the fastapi ecosystem `ormar` is supported in libraries that somehow work with databases.
+
+As of now `ormar` is supported by:
+
+*  [`fastapi-users`](https://github.com/frankie567/fastapi-users)
+*  [`fastapi-crudrouter`](https://github.com/awtkns/fastapi-crudrouter)
+*  [`fastapi-pagination`](https://github.com/uriyyo/fastapi-pagination)
+
+If you maintain or use different library and would like it to support `ormar` let us know how we can help.
+
 ### Dependencies
 
 Ormar is built with:
 
-  * [`SQLAlchemy core`][sqlalchemy-core] for query building.
+  * [`sqlalchemy core`][sqlalchemy-core] for query building.
   * [`databases`][databases] for cross-database async support.
   * [`pydantic`][pydantic] for data validation.
   * `typing_extensions` for python 3.6 - 3.7
+
+### Migrating from `sqlalchemy`
+
+If you currently use `sqlalchemy` and would like to switch to `ormar` check out the auto-translation
+tool that can help you with translating existing sqlalchemy orm models so you do not have to do it manually.
+
+**Beta** versions available at github: [`sqlalchemy-to-ormar`](https://github.com/collerek/sqlalchemy-to-ormar)
+or simply `pip install sqlalchemy-to-ormar`
 
 ### Migrations & Database creation
 

--- a/docs/relations/many-to-many.md
+++ b/docs/relations/many-to-many.md
@@ -161,7 +161,72 @@ The default naming convention is:
    it would be `PostCategory`
 *  for table name it similar but with underscore in between and s in the end of class 
    lowercase name, in example above would be `posts_categorys`
-   
+ 
+### Customizing Through relation names
+
+By default `Through` model relation names default to related model name in lowercase.
+
+So in example like this:
+```python
+... # course declaration ommited
+class Student(ormar.Model):
+    class Meta:
+        database = database
+        metadata = metadata
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+    courses = ormar.ManyToMany(Course)
+
+# will produce default Through model like follows (example simplified)
+class StudentCourse(ormar.Model):
+    class Meta:
+        database = database
+        metadata = metadata
+        tablename = "students_courses"
+
+    id: int = ormar.Integer(primary_key=True)
+    student = ormar.ForeignKey(Student) # default name
+    course = ormar.ForeignKey(Course)  # default name
+```
+
+To customize the names of fields/relation in Through model now you can use new parameters to `ManyToMany`:
+
+* `through_relation_name` - name of the field leading to the model in which `ManyToMany` is declared
+* `through_reverse_relation_name` - name of the field leading to the model to which `ManyToMany` leads to
+
+Example:
+
+```python
+... # course declaration ommited
+class Student(ormar.Model):
+    class Meta:
+        database = database
+        metadata = metadata
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+    courses = ormar.ManyToMany(Course,
+                               through_relation_name="student_id",
+                               through_reverse_relation_name="course_id")
+
+# will produce Through model like follows (example simplified)
+class StudentCourse(ormar.Model):
+    class Meta:
+        database = database
+        metadata = metadata
+        tablename = "students_courses"
+
+    id: int = ormar.Integer(primary_key=True)
+    student_id = ormar.ForeignKey(Student) # set by through_relation_name
+    course_id = ormar.ForeignKey(Course)  # set by through_reverse_relation_name
+```    
+
+!!!note
+    Note that explicitly declaring relations in Through model is forbidden, so even if you
+    provide your own custom Through model you cannot change the names there and you need to use
+    same `through_relation_name` and `through_reverse_relation_name` parameters.
+
 ## Through Fields
 
 The through field is auto added to the reverse side of the relation. 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -13,6 +13,17 @@
   * even if you `select_related` from reverse side of the model the returned models won't be populated in reversed instance (the join is not prevented so you still can `filter` and `order_by`)
   * the relation won't be populated in `dict()` and `json()`
   * you cannot pass the nested related objects when populating from `dict()` or `json()` (also through `fastapi`). It will be either ignored or raise error depending on `extra` setting in pydantic `Config`.
+* `Model.save_related()` now can save whole data tree in once [#148](https://github.com/collerek/ormar/discussions/148)
+  meaning:
+  * it knows if it should save main `Model` or related `Model` first to preserve the relation
+  * it saves main `Model` if 
+    * it's not `saved`,
+    * has no `pk` value 
+    * or `save_all=True` flag is set 
+  
+    in those cases you don't have to split save into two calls (`save()` and `save_related()`)
+  * it supports also `ManyToMany` relations
+  * it supports also optional `Through` model values for m2m relations
 
 ## 🐛 Fixes
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,3 +1,29 @@
+# 0.10.3
+
+## ✨ Features
+
+* `ForeignKey` and `ManyToMany` now support `skip_reverse: bool = False` flag [#118](https://github.com/collerek/ormar/issues/118).
+  If you set `skip_reverse` flag internally the field is still registered on the other 
+  side of the relationship so you can:
+  * `filter` by related models fields from reverse model
+  * `order_by` by related models fields from reverse model 
+  
+  But you cannot:
+  * access the related field from reverse model with `related_name`
+  * even if you `select_related` from reverse side of the model the returned models won't be populated in reversed instance (the join is not prevented so you still can `filter` and `order_by`)
+  * the relation won't be populated in `dict()` and `json()`
+  * you cannot pass the nested related objects when populating from `dict()` or `json()` (also through `fastapi`). It will be either ignored or raise error depending on `extra` setting in pydantic `Config`.
+
+## 🐛 Fixes
+
+*  Fix weakref `ReferenceError` error [#118](https://github.com/collerek/ormar/issues/118)
+*  Fix error raised by Through fields when pydantic `Config.extra="forbid"` is set
+
+## 💬 Other
+*  Introduce link to `sqlalchemy-to-ormar` auto-translator for models
+*  Provide links to fastapi ecosystem libraries that support `ormar`
+
+
 # 0.10.2
 
 ## ✨ Features

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -18,6 +18,7 @@
 
 *  Fix weakref `ReferenceError` error [#118](https://github.com/collerek/ormar/issues/118)
 *  Fix error raised by Through fields when pydantic `Config.extra="forbid"` is set
+*  Fix bug with `pydantic.PrivateAttr` not being initialized at `__init__` [#149](https://github.com/collerek/ormar/issues/149)
 
 ## 💬 Other
 *  Introduce link to `sqlalchemy-to-ormar` auto-translator for models

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -24,6 +24,60 @@
     in those cases you don't have to split save into two calls (`save()` and `save_related()`)
   * it supports also `ManyToMany` relations
   * it supports also optional `Through` model values for m2m relations
+*  Add possibility to customize `Through` model relation field names.
+  * By default `Through` model relation names default to related model name in lowercase.
+    So in example like this:
+    ```python
+    ... # course declaration ommited
+    class Student(ormar.Model):
+        class Meta:
+            database = database
+            metadata = metadata
+    
+        id: int = ormar.Integer(primary_key=True)
+        name: str = ormar.String(max_length=100)
+        courses = ormar.ManyToMany(Course)
+    
+    # will produce default Through model like follows (example simplified)
+    class StudentCourse(ormar.Model):
+        class Meta:
+            database = database
+            metadata = metadata
+            tablename = "students_courses"
+    
+        id: int = ormar.Integer(primary_key=True)
+        student = ormar.ForeignKey(Student) # default name
+        course = ormar.ForeignKey(Course)  # default name
+    ```
+  * To customize the names of fields/relation in Through model now you can use new parameters to `ManyToMany`:
+    * `through_relation_name` - name of the field leading to the model in which `ManyToMany` is declared
+    * `through_reverse_relation_name` - name of the field leading to the model to which `ManyToMany` leads to
+    
+    Example:
+    ```python
+    ... # course declaration ommited
+    class Student(ormar.Model):
+        class Meta:
+            database = database
+            metadata = metadata
+    
+        id: int = ormar.Integer(primary_key=True)
+        name: str = ormar.String(max_length=100)
+        courses = ormar.ManyToMany(Course,
+                                   through_relation_name="student_id",
+                                   through_reverse_relation_name="course_id")
+    
+    # will produce default Through model like follows (example simplified)
+    class StudentCourse(ormar.Model):
+        class Meta:
+            database = database
+            metadata = metadata
+            tablename = "students_courses"
+    
+        id: int = ormar.Integer(primary_key=True)
+        student_id = ormar.ForeignKey(Student) # set by through_relation_name
+        course_id = ormar.ForeignKey(Course)  # set by through_reverse_relation_name
+    ```  
 
 ## 🐛 Fixes
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -30,10 +30,12 @@
 *  Fix weakref `ReferenceError` error [#118](https://github.com/collerek/ormar/issues/118)
 *  Fix error raised by Through fields when pydantic `Config.extra="forbid"` is set
 *  Fix bug with `pydantic.PrivateAttr` not being initialized at `__init__` [#149](https://github.com/collerek/ormar/issues/149)
+*  Fix bug with pydantic-type `exclude` in `dict()` with `__all__` key not working
 
 ## 💬 Other
 *  Introduce link to `sqlalchemy-to-ormar` auto-translator for models
 *  Provide links to fastapi ecosystem libraries that support `ormar`
+*  Add transactions to docs (supported with `databases`)
 
 
 # 0.10.2

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -1,0 +1,88 @@
+# Transactions
+
+Database transactions are supported thanks to `encode/databases` which is used to issue async queries.
+
+## Basic usage
+
+To use transactions use `database.transaction` as async context manager:
+
+```python
+async with database.transaction():
+    # everyting called here will be one transaction
+    await Model1().save()
+    await Model2().save()
+    ...
+```
+
+!!!note
+    Note that it has to be the same `database` that the one used in Model's `Meta` class.
+
+To avoid passing `database` instance around in your code you can extract the instance from each `Model`.
+Database provided during declaration of `ormar.Model` is available through `Meta.database` and can
+be reached from both class and instance.
+
+```python
+import databases
+import sqlalchemy
+import ormar
+
+metadata = sqlalchemy.MetaData()
+database = databases.Database("sqlite:///")
+
+class Author(ormar.Model):
+    class Meta:
+        database=database
+        metadata=metadata
+    
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=255)
+
+# database is accessible from class
+database = Author.Meta.database
+
+# as well as from instance
+author = Author(name="Stephen King")
+database = author.Meta.database
+
+```
+
+You can also use `.transaction()` as a function decorator on any async function:
+
+```python
+@database.transaction()
+async def create_users(request):
+    ...
+```
+
+Transaction blocks are managed as task-local state. Nested transactions
+are fully supported, and are implemented using database savepoints.
+
+## Manual commits/ rollbacks
+
+For a lower-level transaction API you can trigger it manually
+
+```python
+transaction = await database.transaction()
+try:
+    await transaction.start()
+    ...
+except:
+    await transaction.rollback()
+else:
+    await transaction.commit()
+```
+
+
+## Testing
+
+Transactions can also be useful during testing when you can apply force rollback 
+and you do not have to clean the data after each test.
+
+```python
+@pytest.mark.asyncio
+async def sample_test():
+    async with database:
+        async with database.transaction(force_rollback=True):
+            # your test code here
+            ...
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
     - queries/pagination-and-rows-number.md
     - queries/aggregations.md
   - Signals: signals.md
+  - Transactions: transactions.md
   - Use with Fastapi: fastapi.md
   - Use with mypy: mypy.md
   - PyCharm plugin: plugin.md

--- a/ormar/__init__.py
+++ b/ormar/__init__.py
@@ -75,7 +75,7 @@ class UndefinedType:  # pragma no cover
 
 Undefined = UndefinedType()
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"
 __all__ = [
     "Integer",
     "BigInteger",

--- a/ormar/fields/base.py
+++ b/ormar/fields/base.py
@@ -53,6 +53,8 @@ class BaseField(FieldInfo):
             "is_relation", None
         )  # ForeignKeyField + subclasses
         self.is_through: bool = kwargs.pop("is_through", False)  # ThroughFields
+        self.skip_reverse: bool = kwargs.pop("skip_reverse", False)
+        self.skip_field: bool = kwargs.pop("skip_field", False)
 
         self.owner: Type["Model"] = kwargs.pop("owner", None)
         self.to: Type["Model"] = kwargs.pop("to", None)

--- a/ormar/fields/base.py
+++ b/ormar/fields/base.py
@@ -53,6 +53,12 @@ class BaseField(FieldInfo):
             "is_relation", None
         )  # ForeignKeyField + subclasses
         self.is_through: bool = kwargs.pop("is_through", False)  # ThroughFields
+
+        self.through_relation_name = kwargs.pop("through_relation_name", None)
+        self.through_reverse_relation_name = kwargs.pop(
+            "through_reverse_relation_name", None
+        )
+
         self.skip_reverse: bool = kwargs.pop("skip_reverse", False)
         self.skip_field: bool = kwargs.pop("skip_field", False)
 

--- a/ormar/fields/foreign_key.py
+++ b/ormar/fields/foreign_key.py
@@ -318,29 +318,23 @@ class ForeignKeyField(BaseField):
         """
         return self.related_name or self.owner.get_name() + "s"
 
-    def default_target_field_name(self, reverse: bool = False) -> str:
+    def default_target_field_name(self) -> str:
         """
         Returns default target model name on through model.
-        :param reverse: flag to grab name without accessing related field
-        :type reverse: bool
         :return: name of the field
         :rtype: str
         """
-        self_rel_prefix = "from_" if not reverse else "to_"
-        prefix = self_rel_prefix if self.self_reference else ""
-        return f"{prefix}{self.to.get_name()}"
+        prefix = "from_" if self.self_reference else ""
+        return self.through_reverse_relation_name or f"{prefix}{self.to.get_name()}"
 
-    def default_source_field_name(self, reverse: bool = False) -> str:
+    def default_source_field_name(self) -> str:
         """
         Returns default target model name on through model.
-        :param reverse: flag to grab name without accessing related field
-        :type reverse: bool
         :return: name of the field
         :rtype: str
         """
-        self_rel_prefix = "to_" if not reverse else "from_"
-        prefix = self_rel_prefix if self.self_reference else ""
-        return f"{prefix}{self.owner.get_name()}"
+        prefix = "to_" if self.self_reference else ""
+        return self.through_relation_name or f"{prefix}{self.owner.get_name()}"
 
     def evaluate_forward_ref(self, globalns: Any, localns: Any) -> None:
         """

--- a/ormar/fields/foreign_key.py
+++ b/ormar/fields/foreign_key.py
@@ -233,8 +233,12 @@ def ForeignKey(  # noqa CFQ002
 
     owner = kwargs.pop("owner", None)
     self_reference = kwargs.pop("self_reference", False)
+
     orders_by = kwargs.pop("orders_by", None)
     related_orders_by = kwargs.pop("related_orders_by", None)
+
+    skip_reverse = kwargs.pop("skip_reverse", False)
+    skip_field = kwargs.pop("skip_field", False)
 
     validate_not_allowed_fields(kwargs)
 
@@ -274,6 +278,8 @@ def ForeignKey(  # noqa CFQ002
         is_relation=True,
         orders_by=orders_by,
         related_orders_by=related_orders_by,
+        skip_reverse=skip_reverse,
+        skip_field=skip_field,
     )
 
     Field = type("ForeignKey", (ForeignKeyField, BaseField), {})
@@ -311,6 +317,30 @@ class ForeignKeyField(BaseField):
         :rtype: str
         """
         return self.related_name or self.owner.get_name() + "s"
+
+    def default_target_field_name(self, reverse: bool = False) -> str:
+        """
+        Returns default target model name on through model.
+        :param reverse: flag to grab name without accessing related field
+        :type reverse: bool
+        :return: name of the field
+        :rtype: str
+        """
+        self_rel_prefix = "from_" if not reverse else "to_"
+        prefix = self_rel_prefix if self.self_reference else ""
+        return f"{prefix}{self.to.get_name()}"
+
+    def default_source_field_name(self, reverse: bool = False) -> str:
+        """
+        Returns default target model name on through model.
+        :param reverse: flag to grab name without accessing related field
+        :type reverse: bool
+        :return: name of the field
+        :rtype: str
+        """
+        self_rel_prefix = "to_" if not reverse else "from_"
+        prefix = self_rel_prefix if self.self_reference else ""
+        return f"{prefix}{self.owner.get_name()}"
 
     def evaluate_forward_ref(self, globalns: Any, localns: Any) -> None:
         """

--- a/ormar/fields/many_to_many.py
+++ b/ormar/fields/many_to_many.py
@@ -112,10 +112,15 @@ def ManyToMany(
     """
     related_name = kwargs.pop("related_name", None)
     nullable = kwargs.pop("nullable", True)
+
     owner = kwargs.pop("owner", None)
     self_reference = kwargs.pop("self_reference", False)
+
     orders_by = kwargs.pop("orders_by", None)
     related_orders_by = kwargs.pop("related_orders_by", None)
+
+    skip_reverse = kwargs.pop("skip_reverse", False)
+    skip_field = kwargs.pop("skip_field", False)
 
     if through is not None and through.__class__ != ForwardRef:
         forbid_through_relations(cast(Type["Model"], through))
@@ -151,6 +156,8 @@ def ManyToMany(
         is_multi=True,
         orders_by=orders_by,
         related_orders_by=related_orders_by,
+        skip_reverse=skip_reverse,
+        skip_field=skip_field,
     )
 
     Field = type("ManyToMany", (ManyToManyField, BaseField), {})
@@ -183,24 +190,6 @@ class ManyToManyField(ForeignKeyField, ormar.QuerySetProtocol, ormar.RelationPro
             ].related_name
             or self.name
         )
-
-    def default_target_field_name(self) -> str:
-        """
-        Returns default target model name on through model.
-        :return: name of the field
-        :rtype: str
-        """
-        prefix = "from_" if self.self_reference else ""
-        return f"{prefix}{self.to.get_name()}"
-
-    def default_source_field_name(self) -> str:
-        """
-        Returns default target model name on through model.
-        :return: name of the field
-        :rtype: str
-        """
-        prefix = "to_" if self.self_reference else ""
-        return f"{prefix}{self.owner.get_name()}"
 
     def has_unresolved_forward_refs(self) -> bool:
         """

--- a/ormar/fields/many_to_many.py
+++ b/ormar/fields/many_to_many.py
@@ -122,6 +122,9 @@ def ManyToMany(
     skip_reverse = kwargs.pop("skip_reverse", False)
     skip_field = kwargs.pop("skip_field", False)
 
+    through_relation_name = kwargs.pop("through_relation_name", None)
+    through_reverse_relation_name = kwargs.pop("through_reverse_relation_name", None)
+
     if through is not None and through.__class__ != ForwardRef:
         forbid_through_relations(cast(Type["Model"], through))
 
@@ -158,6 +161,8 @@ def ManyToMany(
         related_orders_by=related_orders_by,
         skip_reverse=skip_reverse,
         skip_field=skip_field,
+        through_relation_name=through_relation_name,
+        through_reverse_relation_name=through_reverse_relation_name,
     )
 
     Field = type("ManyToMany", (ManyToManyField, BaseField), {})

--- a/ormar/models/helpers/relations.py
+++ b/ormar/models/helpers/relations.py
@@ -112,6 +112,8 @@ def register_reverse_model_fields(model_field: "ForeignKeyField") -> None:
             self_reference_primary=model_field.self_reference_primary,
             orders_by=model_field.related_orders_by,
             skip_field=model_field.skip_reverse,
+            through_relation_name=model_field.through_reverse_relation_name,
+            through_reverse_relation_name=model_field.through_relation_name,
         )
         # register foreign keys on through model
         model_field = cast("ManyToManyField", model_field)

--- a/ormar/models/helpers/relations.py
+++ b/ormar/models/helpers/relations.py
@@ -111,6 +111,7 @@ def register_reverse_model_fields(model_field: "ForeignKeyField") -> None:
             self_reference=model_field.self_reference,
             self_reference_primary=model_field.self_reference_primary,
             orders_by=model_field.related_orders_by,
+            skip_field=model_field.skip_reverse,
         )
         # register foreign keys on through model
         model_field = cast("ManyToManyField", model_field)
@@ -125,6 +126,7 @@ def register_reverse_model_fields(model_field: "ForeignKeyField") -> None:
             owner=model_field.to,
             self_reference=model_field.self_reference,
             orders_by=model_field.related_orders_by,
+            skip_field=model_field.skip_reverse,
         )
 
 
@@ -145,6 +147,7 @@ def register_through_shortcut_fields(model_field: "ManyToManyField") -> None:
         virtual=True,
         related_name=model_field.name,
         owner=model_field.owner,
+        nullable=True,
     )
 
     model_field.to.Meta.model_fields[through_name] = Through(
@@ -153,6 +156,7 @@ def register_through_shortcut_fields(model_field: "ManyToManyField") -> None:
         virtual=True,
         related_name=related_name,
         owner=model_field.to,
+        nullable=True,
     )
 
 

--- a/ormar/models/metaclass.py
+++ b/ormar/models/metaclass.py
@@ -90,6 +90,7 @@ def add_cached_properties(new_model: Type["Model"]) -> None:
     """
     new_model._quick_access_fields = quick_access_set
     new_model._related_names = None
+    new_model._through_names = None
     new_model._related_fields = None
     new_model._pydantic_fields = {name for name in new_model.__fields__}
     new_model._choices_fields = set()
@@ -536,6 +537,7 @@ class ModelMetaclass(pydantic.main.ModelMetaclass):
                 new_model = populate_meta_tablename_columns_and_pk(name, new_model)
                 populate_meta_sqlalchemy_table_if_required(new_model.Meta)
                 expand_reverse_relationships(new_model)
+                # TODO: iterate only related fields
                 for field in new_model.Meta.model_fields.values():
                     register_relation_in_alias_manager(field=field)
 

--- a/ormar/models/mixins/relation_mixin.py
+++ b/ormar/models/mixins/relation_mixin.py
@@ -4,9 +4,10 @@ from typing import (
     Optional,
     Set,
     TYPE_CHECKING,
+    cast,
 )
 
-from ormar import BaseField
+from ormar import BaseField, ForeignKeyField
 from ormar.models.traversible import NodeList
 
 
@@ -39,7 +40,7 @@ class RelationMixin:
         return self_fields
 
     @classmethod
-    def extract_related_fields(cls) -> List:
+    def extract_related_fields(cls) -> List["ForeignKeyField"]:
         """
         Returns List of ormar Fields for all relations declared on a model.
         List is cached in cls._related_fields for quicker access.
@@ -52,7 +53,7 @@ class RelationMixin:
 
         related_fields = []
         for name in cls.extract_related_names().union(cls.extract_through_names()):
-            related_fields.append(cls.Meta.model_fields[name])
+            related_fields.append(cast("ForeignKeyField", cls.Meta.model_fields[name]))
         cls._related_fields = related_fields
 
         return related_fields

--- a/ormar/models/mixins/save_mixin.py
+++ b/ormar/models/mixins/save_mixin.py
@@ -222,9 +222,7 @@ class SavePrepareMixin(RelationMixin, AliasMixin):
 
     @staticmethod
     async def _upsert_through_model(
-        instance: "Model",
-        previous_model: "Model",
-        relation_field: "ForeignKeyField",
+        instance: "Model", previous_model: "Model", relation_field: "ForeignKeyField",
     ) -> None:
         """
         Upsert through model for m2m relation.

--- a/ormar/models/mixins/save_mixin.py
+++ b/ormar/models/mixins/save_mixin.py
@@ -224,7 +224,7 @@ class SavePrepareMixin(RelationMixin, AliasMixin):
     async def _upsert_through_model(
         instance: "Model",
         previous_model: "Model",
-        relation_field: Optional["ForeignKeyField"],
+        relation_field: "ForeignKeyField",
     ) -> None:
         """
         Upsert through model for m2m relation.

--- a/ormar/models/model.py
+++ b/ormar/models/model.py
@@ -24,7 +24,11 @@ class Model(ModelRow):
         Meta: ModelMeta
 
     def __repr__(self) -> str:  # pragma nocover
-        _repr = {k: getattr(self, k) for k, v in self.Meta.model_fields.items()}
+        _repr = {
+            k: getattr(self, k)
+            for k, v in self.Meta.model_fields.items()
+            if not v.skip_field
+        }
         return f"{self.__class__.__name__}({str(_repr)})"
 
     async def upsert(self: T, **kwargs: Any) -> T:

--- a/ormar/relations/querysetproxy.py
+++ b/ormar/relations/querysetproxy.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:  # pragma no cover
     from ormar.relations import Relation
     from ormar.models import Model, T
     from ormar.queryset import QuerySet
-    from ormar import RelationType
+    from ormar import RelationType, ForeignKeyField
 else:
     T = TypeVar("T", bound="Model")
 
@@ -251,7 +251,7 @@ class QuerysetProxy(Generic[T]):
             owner_column = self._owner.get_name()
         else:
             queryset = ormar.QuerySet(model_cls=self.relation.to)  # type: ignore
-            owner_column = self.related_field.name
+            owner_column = self.related_field_name
         kwargs = {owner_column: self._owner}
         self._clean_items_on_load()
         if keep_reversed and self.type_ == ormar.RelationType.REVERSE:
@@ -367,7 +367,7 @@ class QuerysetProxy(Generic[T]):
         """
         through_kwargs = kwargs.pop(self.through_model_name, {})
         if self.type_ == ormar.RelationType.REVERSE:
-            kwargs[self.related_field.name] = self._owner
+            kwargs[self.related_field_name] = self._owner
         created = await self.queryset.create(**kwargs)
         self._register_related(created)
         if self.type_ == ormar.RelationType.MULTIPLE:

--- a/ormar/relations/querysetproxy.py
+++ b/ormar/relations/querysetproxy.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:  # pragma no cover
     from ormar.relations import Relation
     from ormar.models import Model, T
     from ormar.queryset import QuerySet
-    from ormar import RelationType, ForeignKeyField
+    from ormar import RelationType
 else:
     T = TypeVar("T", bound="Model")
 

--- a/tests/test_fastapi/test_nested_saving.py
+++ b/tests/test_fastapi/test_nested_saving.py
@@ -1,0 +1,106 @@
+import json
+from typing import List, Optional
+
+import databases
+import pytest
+import sqlalchemy
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+import ormar
+from tests.settings import DATABASE_URL
+
+app = FastAPI()
+metadata = sqlalchemy.MetaData()
+database = databases.Database(DATABASE_URL, force_rollback=True)
+app.state.database = database
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    database_ = app.state.database
+    if not database_.is_connected:
+        await database_.connect()
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    database_ = app.state.database
+    if database_.is_connected:
+        await database_.disconnect()
+
+
+class Department(ormar.Model):
+    class Meta:
+        database = database
+        metadata = metadata
+
+    id: int = ormar.Integer(primary_key=True)
+    department_name: str = ormar.String(max_length=100)
+
+
+class Course(ormar.Model):
+    class Meta:
+        database = database
+        metadata = metadata
+
+    id: int = ormar.Integer(primary_key=True)
+    course_name: str = ormar.String(max_length=100)
+    completed: bool = ormar.Boolean()
+    department: Optional[Department] = ormar.ForeignKey(Department)
+
+
+# create db and tables
+@pytest.fixture(autouse=True, scope="module")
+def create_test_database():
+    engine = sqlalchemy.create_engine(DATABASE_URL)
+    metadata.create_all(engine)
+    yield
+    metadata.drop_all(engine)
+
+
+@app.post("/DepartmentWithCourses/", response_model=Department)
+async def create_department(department: Department):
+    # there is no save all - you need to split into save and save_related
+    await department.save()
+    await department.save_related(follow=True, save_all=True)
+    return department
+
+
+@app.get("/DepartmentsAll/", response_model=List[Department])
+async def get_Courses():
+    # if you don't provide default name it related model name + s so courses not course
+    departmentall = await Department.objects.select_related("courses").all()
+    return departmentall
+
+
+def test_saving_related_in_fastapi():
+    client = TestClient(app)
+    with client as client:
+        payload = {
+            "department_name": "Ormar",
+            "courses": [
+                {"course_name": "basic1", "completed": True},
+                {"course_name": "basic2", "completed": True},
+            ],
+        }
+        response = client.post("/DepartmentWithCourses/", data=json.dumps(payload))
+        department = Department(**response.json())
+
+        assert department.id is not None
+        assert len(department.courses) == 2
+        assert department.department_name == "Ormar"
+        assert department.courses[0].course_name == "basic1"
+        assert department.courses[0].completed
+        assert department.courses[1].course_name == "basic2"
+        assert department.courses[1].completed
+
+        response = client.get("/DepartmentsAll/")
+        departments = [Department(**x) for x in response.json()]
+        assert departments[0].id is not None
+        assert len(departments[0].courses) == 2
+        assert departments[0].department_name == "Ormar"
+        assert departments[0].courses[0].course_name == "basic1"
+        assert departments[0].courses[0].completed
+        assert departments[0].courses[1].course_name == "basic2"
+        assert departments[0].courses[1].completed

--- a/tests/test_fastapi/test_skip_reverse_models.py
+++ b/tests/test_fastapi/test_skip_reverse_models.py
@@ -1,0 +1,148 @@
+import json
+from typing import List, Optional
+
+import databases
+import pytest
+import sqlalchemy
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+import ormar
+from tests.settings import DATABASE_URL
+
+app = FastAPI()
+metadata = sqlalchemy.MetaData()
+database = databases.Database(DATABASE_URL, force_rollback=True)
+app.state.database = database
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    database_ = app.state.database
+    if not database_.is_connected:
+        await database_.connect()
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    database_ = app.state.database
+    if database_.is_connected:
+        await database_.disconnect()
+
+
+class BaseMeta(ormar.ModelMeta):
+    database = database
+    metadata = metadata
+
+
+class Author(ormar.Model):
+    class Meta(BaseMeta):
+        pass
+
+    id: int = ormar.Integer(primary_key=True)
+    first_name: str = ormar.String(max_length=80)
+    last_name: str = ormar.String(max_length=80)
+
+
+class Category(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "categories"
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=40)
+
+
+class Post(ormar.Model):
+    class Meta(BaseMeta):
+        pass
+
+    id: int = ormar.Integer(primary_key=True)
+    title: str = ormar.String(max_length=200)
+    categories = ormar.ManyToMany(Category, skip_reverse=True)
+    author: Optional[Author] = ormar.ForeignKey(Author, skip_reverse=True)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def create_test_database():
+    engine = sqlalchemy.create_engine(DATABASE_URL)
+    metadata.create_all(engine)
+    yield
+    metadata.drop_all(engine)
+
+
+@app.post("/categories/", response_model=Category)
+async def create_category(category: Category):
+    await category.save()
+    await category.save_related(follow=True, save_all=True)
+    return category
+
+
+@app.post("/posts/", response_model=Post)
+async def create_post(post: Post):
+    if post.author:
+        await post.author.save()
+    await post.save()
+    await post.save_related(follow=True, save_all=True)
+    for category in [cat for cat in post.categories]:
+        await post.categories.add(category)
+    return post
+
+
+@app.get("/categories/", response_model=List[Category])
+async def get_categories():
+    return await Category.objects.select_related("posts").all()
+
+
+@app.get("/posts/", response_model=List[Post])
+async def get_posts():
+    posts = await Post.objects.select_related(["categories", "author"]).all()
+    return posts
+
+
+def test_queries():
+    client = TestClient(app)
+    with client as client:
+        right_category = {"name": "Test category"}
+        wrong_category = {"name": "Test category2", "posts": [{"title": "Test Post"}]}
+
+        # cannot add posts if skipped, will be ignored (with extra=ignore by default)
+        response = client.post("/categories/", data=json.dumps(wrong_category))
+        assert response.status_code == 200
+        response = client.get("/categories/")
+        assert response.status_code == 200
+        assert not "posts" in response.json()
+        categories = [Category(**x) for x in response.json()]
+        assert categories[0] is not None
+        assert categories[0].name == "Test category2"
+
+        response = client.post("/categories/", data=json.dumps(right_category))
+        assert response.status_code == 200
+
+        response = client.get("/categories/")
+        assert response.status_code == 200
+        categories = [Category(**x) for x in response.json()]
+        assert categories[1] is not None
+        assert categories[1].name == "Test category"
+
+        right_post = {
+            "title": "ok post",
+            "author": {"first_name": "John", "last_name": "Smith"},
+            "categories": [{"name": "New cat"}],
+        }
+        response = client.post("/posts/", data=json.dumps(right_post))
+        assert response.status_code == 200
+
+        Category.__config__.extra = "allow"
+        response = client.get("/posts/")
+        assert response.status_code == 200
+        posts = [Post(**x) for x in response.json()]
+        assert posts[0].title == "ok post"
+        assert posts[0].author.first_name == "John"
+        assert posts[0].categories[0].name == "New cat"
+
+        wrong_category = {"name": "Test category3", "posts": [{"title": "Test Post"}]}
+
+        # cannot add posts if skipped, will be error with extra forbid
+        Category.__config__.extra = "forbid"
+        response = client.post("/categories/", data=json.dumps(wrong_category))
+        assert response.status_code == 422

--- a/tests/test_fastapi/test_wekref_exclusion.py
+++ b/tests/test_fastapi/test_wekref_exclusion.py
@@ -123,6 +123,16 @@ async def get_test_5(thing_id: UUID):
     return await Thing.objects.all(other_thing__id=thing_id)
 
 
+@app.get(
+    "/test/error", response_model=List[Thing], response_model_exclude={"other_thing"}
+)
+async def get_weakref():
+    ots = await OtherThing.objects.all()
+    ot = ots[0]
+    ts = await ot.things.all()
+    return ts
+
+
 def test_endpoints():
     client = TestClient(app)
     with client:
@@ -145,3 +155,7 @@ def test_endpoints():
         resp5 = client.get(f"/test/5/{ot.id}")
         assert resp5.status_code == 200
         assert len(resp5.json()) == 3
+
+        resp6 = client.get("/test/error")
+        assert resp6.status_code == 200
+        assert len(resp6.json()) == 3

--- a/tests/test_model_definition/test_pydantic_private_attributes.py
+++ b/tests/test_model_definition/test_pydantic_private_attributes.py
@@ -1,0 +1,34 @@
+from typing import List
+
+import databases
+import sqlalchemy
+from pydantic import PrivateAttr
+
+import ormar
+from tests.settings import DATABASE_URL
+
+database = databases.Database(DATABASE_URL, force_rollback=True)
+metadata = sqlalchemy.MetaData()
+
+
+class BaseMeta(ormar.ModelMeta):
+    metadata = metadata
+    database = database
+
+
+class Subscription(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "subscriptions"
+
+    id: int = ormar.Integer(primary_key=True)
+    stripe_subscription_id: str = ormar.String(nullable=False, max_length=256)
+
+    _add_payments: List[str] = PrivateAttr(default_factory=list)
+
+    def add_payment(self, payment: str):
+        self._add_payments.append(payment)
+
+
+def test_private_attribute():
+    sub = Subscription(stripe_subscription_id="2312312sad231")
+    sub.add_payment("test")

--- a/tests/test_model_methods/test_save_related.py
+++ b/tests/test_model_methods/test_save_related.py
@@ -119,7 +119,7 @@ async def test_saving_many_to_many():
             assert count == 0
 
             count = await hq.save_related(save_all=True)
-            assert count == 2
+            assert count == 3
 
             hq.nicks[0].name = "Kabucha"
             hq.nicks[1].name = "Kabucha2"

--- a/tests/test_model_methods/test_save_related_from_dict.py
+++ b/tests/test_model_methods/test_save_related_from_dict.py
@@ -1,0 +1,256 @@
+from typing import List
+
+import databases
+import pytest
+import sqlalchemy
+
+import ormar
+from tests.settings import DATABASE_URL
+
+database = databases.Database(DATABASE_URL, force_rollback=True)
+metadata = sqlalchemy.MetaData()
+
+
+class CringeLevel(ormar.Model):
+    class Meta:
+        tablename = "levels"
+        metadata = metadata
+        database = database
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+
+
+class NickName(ormar.Model):
+    class Meta:
+        tablename = "nicks"
+        metadata = metadata
+        database = database
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100, nullable=False, name="hq_name")
+    is_lame: bool = ormar.Boolean(nullable=True)
+    level: CringeLevel = ormar.ForeignKey(CringeLevel)
+
+
+class NicksHq(ormar.Model):
+    class Meta:
+        tablename = "nicks_x_hq"
+        metadata = metadata
+        database = database
+
+    id: int = ormar.Integer(primary_key=True)
+    new_field: str = ormar.String(max_length=200, nullable=True)
+
+
+class HQ(ormar.Model):
+    class Meta:
+        tablename = "hqs"
+        metadata = metadata
+        database = database
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100, nullable=False, name="hq_name")
+    nicks: List[NickName] = ormar.ManyToMany(NickName, through=NicksHq)
+
+
+class Company(ormar.Model):
+    class Meta:
+        tablename = "companies"
+        metadata = metadata
+        database = database
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100, nullable=False, name="company_name")
+    founded: int = ormar.Integer(nullable=True)
+    hq: HQ = ormar.ForeignKey(HQ, related_name="companies")
+
+
+@pytest.fixture(autouse=True, scope="module")
+def create_test_database():
+    engine = sqlalchemy.create_engine(DATABASE_URL)
+    metadata.drop_all(engine)
+    metadata.create_all(engine)
+    yield
+    metadata.drop_all(engine)
+
+
+@pytest.mark.asyncio
+async def test_saving_related_reverse_fk():
+    async with database:
+        async with database.transaction(force_rollback=True):
+            payload = {"companies": [{"name": "Banzai"}], "name": "Main"}
+            hq = HQ(**payload)
+            count = await hq.save_related(follow=True, save_all=True)
+            assert count == 2
+
+            hq_check = await HQ.objects.select_related("companies").get()
+            assert hq_check.pk is not None
+            assert hq_check.name == "Main"
+            assert len(hq_check.companies) == 1
+            assert hq_check.companies[0].name == "Banzai"
+            assert hq_check.companies[0].pk is not None
+
+
+@pytest.mark.asyncio
+async def test_saving_related_reverse_fk_multiple():
+    async with database:
+        async with database.transaction(force_rollback=True):
+            payload = {
+                "companies": [{"name": "Banzai"}, {"name": "Yamate"}],
+                "name": "Main",
+            }
+            hq = HQ(**payload)
+            count = await hq.save_related(follow=True, save_all=True)
+            assert count == 3
+
+            hq_check = await HQ.objects.select_related("companies").get()
+            assert hq_check.pk is not None
+            assert hq_check.name == "Main"
+            assert len(hq_check.companies) == 2
+            assert hq_check.companies[0].name == "Banzai"
+            assert hq_check.companies[0].pk is not None
+            assert hq_check.companies[1].name == "Yamate"
+            assert hq_check.companies[1].pk is not None
+
+
+@pytest.mark.asyncio
+async def test_saving_related_fk():
+    async with database:
+        async with database.transaction(force_rollback=True):
+            payload = {"hq": {"name": "Main"}, "name": "Banzai"}
+            comp = Company(**payload)
+            count = await comp.save_related(follow=True, save_all=True)
+            assert count == 2
+
+            comp_check = await Company.objects.select_related("hq").get()
+            assert comp_check.pk is not None
+            assert comp_check.name == "Banzai"
+            assert comp_check.hq.name == "Main"
+            assert comp_check.hq.pk is not None
+
+
+@pytest.mark.asyncio
+async def test_saving_many_to_many_wo_through():
+    async with database:
+        async with database.transaction(force_rollback=True):
+            payload = {
+                "name": "Main",
+                "nicks": [
+                    {"name": "Bazinga0", "is_lame": False},
+                    {"name": "Bazinga20", "is_lame": True},
+                ],
+            }
+
+            hq = HQ(**payload)
+            count = await hq.save_related()
+            assert count == 3
+
+            hq_check = await HQ.objects.select_related("nicks").get()
+            assert hq_check.pk is not None
+            assert len(hq_check.nicks) == 2
+            assert hq_check.nicks[0].name == "Bazinga0"
+            assert hq_check.nicks[1].name == "Bazinga20"
+
+
+@pytest.mark.asyncio
+async def test_saving_many_to_many_with_through():
+    async with database:
+        async with database.transaction(force_rollback=True):
+            async with database.transaction(force_rollback=True):
+                payload = {
+                    "name": "Main",
+                    "nicks": [
+                        {
+                            "name": "Bazinga0",
+                            "is_lame": False,
+                            "nickshq": {"new_field": "test"},
+                        },
+                        {
+                            "name": "Bazinga20",
+                            "is_lame": True,
+                            "nickshq": {"new_field": "test2"},
+                        },
+                    ],
+                }
+
+                hq = HQ(**payload)
+                count = await hq.save_related()
+                assert count == 3
+
+                hq_check = await HQ.objects.select_related("nicks").get()
+                assert hq_check.pk is not None
+                assert len(hq_check.nicks) == 2
+                assert hq_check.nicks[0].name == "Bazinga0"
+                assert hq_check.nicks[0].nickshq.new_field == "test"
+                assert hq_check.nicks[1].name == "Bazinga20"
+                assert hq_check.nicks[1].nickshq.new_field == "test2"
+
+
+@pytest.mark.asyncio
+async def test_saving_nested_with_m2m_and_rev_fk():
+    async with database:
+        async with database.transaction(force_rollback=True):
+            payload = {
+                "name": "Main",
+                "nicks": [
+                    {"name": "Bazinga0", "is_lame": False, "level": {"name": "High"}},
+                    {"name": "Bazinga20", "is_lame": True, "level": {"name": "Low"}},
+                ],
+            }
+
+            hq = HQ(**payload)
+            count = await hq.save_related(follow=True, save_all=True)
+            assert count == 5
+
+            hq_check = await HQ.objects.select_related("nicks__level").get()
+            assert hq_check.pk is not None
+            assert len(hq_check.nicks) == 2
+            assert hq_check.nicks[0].name == "Bazinga0"
+            assert hq_check.nicks[0].level.name == "High"
+            assert hq_check.nicks[1].name == "Bazinga20"
+            assert hq_check.nicks[1].level.name == "Low"
+
+
+@pytest.mark.asyncio
+async def test_saving_nested_with_m2m_and_rev_fk_and_through():
+    async with database:
+        async with database.transaction(force_rollback=True):
+            payload = {
+                "hq": {
+                    "name": "Yoko",
+                    "nicks": [
+                        {
+                            "name": "Bazinga0",
+                            "is_lame": False,
+                            "nickshq": {"new_field": "test"},
+                            "level": {"name": "High"},
+                        },
+                        {
+                            "name": "Bazinga20",
+                            "is_lame": True,
+                            "nickshq": {"new_field": "test2"},
+                            "level": {"name": "Low"},
+                        },
+                    ],
+                },
+                "name": "Main",
+            }
+
+            company = Company(**payload)
+            count = await company.save_related(follow=True, save_all=True)
+            assert count == 6
+
+            company_check = await Company.objects.select_related(
+                "hq__nicks__level"
+            ).get()
+            assert company_check.pk is not None
+            assert company_check.name == "Main"
+            assert company_check.hq.name == "Yoko"
+            assert len(company_check.hq.nicks) == 2
+            assert company_check.hq.nicks[0].name == "Bazinga0"
+            assert company_check.hq.nicks[0].nickshq.new_field == "test"
+            assert company_check.hq.nicks[0].level.name == "High"
+            assert company_check.hq.nicks[1].name == "Bazinga20"
+            assert company_check.hq.nicks[1].level.name == "Low"
+            assert company_check.hq.nicks[1].nickshq.new_field == "test2"

--- a/tests/test_relations/test_customizing_through_model_relation_names.py
+++ b/tests/test_relations/test_customizing_through_model_relation_names.py
@@ -1,0 +1,84 @@
+import databases
+import pytest
+import sqlalchemy
+
+import ormar
+from tests.settings import DATABASE_URL
+
+metadata = sqlalchemy.MetaData()
+database = databases.Database(DATABASE_URL, force_rollback=True)
+
+
+class Course(ormar.Model):
+    class Meta:
+        database = database
+        metadata = metadata
+
+    id: int = ormar.Integer(primary_key=True)
+    course_name: str = ormar.String(max_length=100)
+
+
+class Student(ormar.Model):
+    class Meta:
+        database = database
+        metadata = metadata
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+    courses = ormar.ManyToMany(
+        Course,
+        through_relation_name="student_id",
+        through_reverse_relation_name="course_id",
+    )
+
+
+# create db and tables
+@pytest.fixture(autouse=True, scope="module")
+def create_test_database():
+    engine = sqlalchemy.create_engine(DATABASE_URL)
+    metadata.create_all(engine)
+    yield
+    metadata.drop_all(engine)
+
+
+def test_tables_columns():
+    through_meta = Student.Meta.model_fields["courses"].through.Meta
+    assert "course_id" in through_meta.table.c
+    assert "student_id" in through_meta.table.c
+    assert "course_id" in through_meta.model_fields
+    assert "student_id" in through_meta.model_fields
+
+
+@pytest.mark.asyncio
+async def test_working_with_changed_through_names():
+    async with database:
+        async with database.transaction(force_rollback=True):
+            to_save = {
+                "course_name": "basic1",
+                "students": [{"name": "Jack"}, {"name": "Abi"}],
+            }
+            await Course(**to_save).save_related(follow=True, save_all=True)
+            course_check = await Course.objects.select_related("students").get()
+
+            assert course_check.course_name == "basic1"
+            assert course_check.students[0].name == "Jack"
+            assert course_check.students[1].name == "Abi"
+
+            students = await course_check.students.all()
+            assert len(students) == 2
+
+            student = await course_check.students.get(name="Jack")
+            assert student.name == "Jack"
+
+            students = await Student.objects.select_related("courses").all(
+                courses__course_name="basic1"
+            )
+            assert len(students) == 2
+
+            course_check = (
+                await Course.objects.select_related("students")
+                .order_by("students__name")
+                .get()
+            )
+            assert course_check.students[0].name == "Abi"
+            assert course_check.students[1].name == "Jack"

--- a/tests/test_relations/test_skipping_reverse.py
+++ b/tests/test_relations/test_skipping_reverse.py
@@ -1,0 +1,223 @@
+from typing import List, Optional
+
+import databases
+import pytest
+import sqlalchemy
+
+import ormar
+from tests.settings import DATABASE_URL
+
+database = databases.Database(DATABASE_URL)
+metadata = sqlalchemy.MetaData()
+
+
+class BaseMeta(ormar.ModelMeta):
+    database = database
+    metadata = metadata
+
+
+class Author(ormar.Model):
+    class Meta(BaseMeta):
+        pass
+
+    id: int = ormar.Integer(primary_key=True)
+    first_name: str = ormar.String(max_length=80)
+    last_name: str = ormar.String(max_length=80)
+
+
+class Category(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "categories"
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=40)
+
+
+class Post(ormar.Model):
+    class Meta(BaseMeta):
+        pass
+
+    id: int = ormar.Integer(primary_key=True)
+    title: str = ormar.String(max_length=200)
+    categories: Optional[List[Category]] = ormar.ManyToMany(Category, skip_reverse=True)
+    author: Optional[Author] = ormar.ForeignKey(Author, skip_reverse=True)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def create_test_database():
+    engine = sqlalchemy.create_engine(DATABASE_URL)
+    metadata.create_all(engine)
+    yield
+    metadata.drop_all(engine)
+
+
+@pytest.fixture(scope="function")
+async def cleanup():
+    yield
+    async with database:
+        PostCategory = Post.Meta.model_fields["categories"].through
+        await PostCategory.objects.delete(each=True)
+        await Post.objects.delete(each=True)
+        await Category.objects.delete(each=True)
+        await Author.objects.delete(each=True)
+
+
+def test_model_definition():
+    category = Category(name="Test")
+    author = Author(first_name="Test", last_name="Author")
+    post = Post(title="Test Post", author=author)
+    post.categories = category
+
+    assert post.categories[0] == category
+    assert post.author == author
+
+    with pytest.raises(AttributeError):
+        assert author.posts
+
+    with pytest.raises(AttributeError):
+        assert category.posts
+
+    assert "posts" not in category._orm
+
+
+@pytest.mark.asyncio
+async def test_assigning_related_objects(cleanup):
+    async with database:
+        guido = await Author.objects.create(first_name="Guido", last_name="Van Rossum")
+        post = await Post.objects.create(title="Hello, M2M", author=guido)
+        news = await Category.objects.create(name="News")
+
+        # Add a category to a post.
+        await post.categories.add(news)
+        # other way is disabled
+        with pytest.raises(AttributeError):
+            await news.posts.add(post)
+
+        assert await post.categories.get_or_none(name="no exist") is None
+        assert await post.categories.get_or_none(name="News") == news
+
+        # Creating columns object from instance:
+        await post.categories.create(name="Tips")
+        assert len(post.categories) == 2
+
+        post_categories = await post.categories.all()
+        assert len(post_categories) == 2
+
+        category = await Category.objects.select_related("posts").get(name="News")
+        with pytest.raises(AttributeError):
+            assert category.posts
+
+
+@pytest.mark.asyncio
+async def test_quering_of_related_model_works_but_no_result(cleanup):
+    async with database:
+        guido = await Author.objects.create(first_name="Guido", last_name="Van Rossum")
+        post = await Post.objects.create(title="Hello, M2M", author=guido)
+        news = await Category.objects.create(name="News")
+
+        await post.categories.add(news)
+
+        post_categories = await post.categories.all()
+        assert len(post_categories) == 1
+
+        assert "posts" not in post.dict().get("categories", [])[0]
+
+        assert news == await post.categories.get(name="News")
+
+        posts_about_python = await Post.objects.filter(categories__name="python").all()
+        assert len(posts_about_python) == 0
+
+        # relation not in dict
+        category = (
+            await Category.objects.select_related("posts")
+            .filter(posts__author=guido)
+            .get()
+        )
+        assert category == news
+        assert "posts" not in category.dict()
+
+        # relation not in json
+        category2 = (
+            await Category.objects.select_related("posts")
+            .filter(posts__author__first_name="Guido")
+            .get()
+        )
+        assert category2 == news
+        assert "posts" not in category2.json()
+
+        assert "posts" not in Category.schema().get("properties")
+
+
+@pytest.mark.asyncio
+async def test_removal_of_the_relations(cleanup):
+    async with database:
+        guido = await Author.objects.create(first_name="Guido", last_name="Van Rossum")
+        post = await Post.objects.create(title="Hello, M2M", author=guido)
+        news = await Category.objects.create(name="News")
+        await post.categories.add(news)
+        assert len(await post.categories.all()) == 1
+        await post.categories.remove(news)
+        assert len(await post.categories.all()) == 0
+
+        with pytest.raises(AttributeError):
+            await news.posts.add(post)
+        with pytest.raises(AttributeError):
+            await news.posts.remove(post)
+
+        await post.categories.add(news)
+        await post.categories.clear()
+        assert len(await post.categories.all()) == 0
+
+        await post.categories.add(news)
+        await news.delete()
+        assert len(await post.categories.all()) == 0
+
+
+@pytest.mark.asyncio
+async def test_selecting_related(cleanup):
+    async with database:
+        guido = await Author.objects.create(first_name="Guido", last_name="Van Rossum")
+        guido2 = await Author.objects.create(
+            first_name="Guido2", last_name="Van Rossum"
+        )
+
+        post = await Post.objects.create(title="Hello, M2M", author=guido)
+        post2 = await Post.objects.create(title="Bye, M2M", author=guido2)
+
+        news = await Category.objects.create(name="News")
+        recent = await Category.objects.create(name="Recent")
+
+        await post.categories.add(news)
+        await post.categories.add(recent)
+        await post2.categories.add(recent)
+
+        assert len(await post.categories.all()) == 2
+        assert (await post.categories.limit(1).all())[0] == news
+        assert (await post.categories.offset(1).limit(1).all())[0] == recent
+        assert await post.categories.first() == news
+        assert await post.categories.exists()
+
+        # still can order
+        categories = (
+            await Category.objects.select_related("posts")
+            .order_by("posts__title")
+            .all()
+        )
+        assert categories[0].name == "Recent"
+        assert categories[1].name == "News"
+
+        # still can filter
+        categories = await Category.objects.filter(posts__title="Bye, M2M").all()
+        assert categories[0].name == "Recent"
+        assert len(categories) == 1
+
+        # same for reverse fk
+        authors = (
+            await Author.objects.select_related("posts").order_by("posts__title").all()
+        )
+        assert authors[0].first_name == "Guido2"
+        assert authors[1].first_name == "Guido"
+
+        authors = await Author.objects.filter(posts__title="Bye, M2M").all()
+        assert authors[0].first_name == "Guido2"
+        assert len(authors) == 1


### PR DESCRIPTION
# 0.10.3

## ✨ Features

* `ForeignKey` and `ManyToMany` now support `skip_reverse: bool = False` flag [#118](https://github.com/collerek/ormar/issues/118).
  If you set `skip_reverse` flag internally the field is still registered on the other 
  side of the relationship so you can:
  * `filter` by related models fields from reverse model
  * `order_by` by related models fields from reverse model 
  
  But you cannot:
  * access the related field from reverse model with `related_name`
  * even if you `select_related` from reverse side of the model the returned models won't be populated in reversed instance (the join is not prevented so you still can `filter` and `order_by`)
  * the relation won't be populated in `dict()` and `json()`
  * you cannot pass the nested related objects when populating from `dict()` or `json()` (also through `fastapi`). It will be either ignored or raise error depending on `extra` setting in pydantic `Config`.
* `Model.save_related()` now can save whole data tree in once [#148](https://github.com/collerek/ormar/discussions/148)
  meaning:
  * it knows if it should save main `Model` or related `Model` first to preserve the relation
  * it saves main `Model` if 
    * it's not `saved`,
    * has no `pk` value 
    * or `save_all=True` flag is set 
  
    in those cases you don't have to split save into two calls (`save()` and `save_related()`)
  * it supports also `ManyToMany` relations
  * it supports also optional `Through` model values for m2m relations
*  Add possibility to customize `Through` model relation field names.
  * By default `Through` model relation names default to related model name in lowercase.
    So in example like this:
    ```python
    ... # course declaration ommited
    class Student(ormar.Model):
        class Meta:
            database = database
            metadata = metadata
    
        id: int = ormar.Integer(primary_key=True)
        name: str = ormar.String(max_length=100)
        courses = ormar.ManyToMany(Course)
    
    # will produce default Through model like follows (example simplified)
    class StudentCourse(ormar.Model):
        class Meta:
            database = database
            metadata = metadata
            tablename = "students_courses"
    
        id: int = ormar.Integer(primary_key=True)
        student = ormar.ForeignKey(Student) # default name
        course = ormar.ForeignKey(Course)  # default name
    ```
  * To customize the names of fields/relation in Through model now you can use new parameters to `ManyToMany`:
    * `through_relation_name` - name of the field leading to the model in which `ManyToMany` is declared
    * `through_reverse_relation_name` - name of the field leading to the model to which `ManyToMany` leads to
    
    Example:
    ```python
    ... # course declaration ommited
    class Student(ormar.Model):
        class Meta:
            database = database
            metadata = metadata
    
        id: int = ormar.Integer(primary_key=True)
        name: str = ormar.String(max_length=100)
        courses = ormar.ManyToMany(Course,
                                   through_relation_name="student_id",
                                   through_reverse_relation_name="course_id")
    
    # will produce default Through model like follows (example simplified)
    class StudentCourse(ormar.Model):
        class Meta:
            database = database
            metadata = metadata
            tablename = "students_courses"
    
        id: int = ormar.Integer(primary_key=True)
        student_id = ormar.ForeignKey(Student) # set by through_relation_name
        course_id = ormar.ForeignKey(Course)  # set by through_reverse_relation_name
    ```  