### PR TITLE
fix typos in Python-style filters documentation

### DIFF
--- a/docs/queries/filter-and-sort.md
+++ b/docs/queries/filter-and-sort.md
@@ -156,13 +156,13 @@ Some samples:
 ```python
 # sql: ( product.name = 'Test'  AND  product.rating >= 3.0 ) 
 Product.objects.filter(
-    (Product.name == 'Test') & (Product.rating >=3.0)
+    (Product.name == 'Test') & (Product.rating >= 3.0)
 ).get()
 
 # sql: ( product.name = 'Test' AND product.rating >= 3.0 ) 
 #       OR (categories.name IN ('Toys', 'Books'))
 Product.objects.filter(
-        ((Product.name='Test') & (Product.rating >= 3.0)) | 
+        ((Product.name == 'Test') & (Product.rating >= 3.0)) | 
         (Product.categories.name << ['Toys', 'Books'])
     ).get()
 ```


### PR DESCRIPTION
The GitHub web editor did something on the last line, not sure what (probably added a trailing new line).