### PR TITLE
Fix grammar in queries docs

### DIFF
--- a/docs/queries/index.md
+++ b/docs/queries/index.md
@@ -17,7 +17,7 @@ divided into categories according to the function they fulfill.
 
 Note that some functions/methods are in multiple categories.
 
-For complicity also Models and relations methods are listed.
+For completeness, Models and relation methods are listed.
 
 To read more about any specific section or function please refer to the details subpage.
 


### PR DESCRIPTION
I believe `completeness` was the intended word rather than `complicity`?