### PR TITLE
Fix populate_default_values

### DIFF
--- a/ormar/models/mixins/save_mixin.py
+++ b/ormar/models/mixins/save_mixin.py
@@ -164,7 +164,10 @@ class SavePrepareMixin(RelationMixin, AliasMixin):
             ):
                 new_kwargs[field_name] = field.get_default()
             # clear fields with server_default set as None
-            if field.server_default is not None and not new_kwargs.get(field_name):
+            if (
+                field.server_default is not None
+                and new_kwargs.get(field_name, None) is None
+            ):
                 new_kwargs.pop(field_name, None)
         return new_kwargs
 

--- a/tests/test_model_methods/test_populate_default_values.py
+++ b/tests/test_model_methods/test_populate_default_values.py
@@ -1,0 +1,41 @@
+import databases
+import pytest
+import sqlalchemy
+from sqlalchemy import text
+
+import ormar
+from tests.settings import DATABASE_URL
+
+database = databases.Database(DATABASE_URL, force_rollback=True)
+metadata = sqlalchemy.MetaData()
+
+
+class BaseMeta(ormar.ModelMeta):
+    database = database
+    metadata = metadata
+
+
+class Task(ormar.Model):
+    class Meta(BaseMeta):
+        tablename = "tasks"
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(
+        max_length=255, minimum=0, server_default=text("Default Name"), nullable=False
+    )
+    points: int = ormar.Integer(
+        default=0, minimum=0, server_default=text("0"), nullable=False
+    )
+
+
+def test_populate_default_values():
+    new_kwargs = {
+        "id": None,
+        "name": "",
+        "points": 0,
+    }
+    result = Task.populate_default_values(new_kwargs)
+
+    assert result["id"] is None
+    assert result["name"] == ""
+    assert result["points"] == 0


### PR DESCRIPTION
Bug:  Set field value to null when specifying server_default_value and bool (value) == False (empty string, False or 0).

```
class ExampleModel(Model):
  some_field = Integer(server_default_value=sa.text('0'), default=0, nullable=False)

await ExampleModel.objects.create(some_field=0)
```
  