### PR TITLE
add method `find_or_create`

### DIFF
--- a/ormar/models/helpers/models.py
+++ b/ormar/models/helpers/models.py
@@ -59,6 +59,8 @@ def populate_default_options_values(  # noqa: CCR001
         new_model.Meta.orders_by = []
     if not hasattr(new_model.Meta, "exclude_parent_fields"):
         new_model.Meta.exclude_parent_fields = []
+    if not hasattr(new_model.Meta, "debug"):
+        new_model.Meta.debug = False
 
     if any(
         is_field_an_forward_ref(field) for field in new_model.Meta.model_fields.values()

--- a/ormar/models/metaclass.py
+++ b/ormar/models/metaclass.py
@@ -85,6 +85,7 @@ class ModelMeta:
     orders_by: List[str]
     exclude_parent_fields: List[str]
     extra: Extra
+    debug: bool  # if it's true, show the raw select sql
 
 
 def add_cached_properties(new_model: Type["Model"]) -> None:

--- a/ormar/queryset/query.py
+++ b/ormar/queryset/query.py
@@ -156,8 +156,8 @@ class Query:
         expr = expr.select_from(self.select_from)
 
         expr = self._apply_expression_modifiers(expr)
-
-        # print("\n", expr.compile(compile_kwargs={"literal_binds": True}))
+        if self.model_cls.Meta.debug:
+            print("\n", expr.compile(compile_kwargs={"literal_binds": True}))
         self._reset_query_parameters()
 
         return expr

--- a/ormar/queryset/queryset.py
+++ b/ormar/queryset/queryset.py
@@ -993,6 +993,26 @@ class QuerySet(Generic[T]):
         except NoMatch:
             return await self.create(**kwargs)
 
+    async def find_or_create(self, *args: Any, **kwargs: Any) -> Tuple["T", bool]:
+        """
+        A new method to combination of create and get methods.
+        because should be keeping compatible for `get_or_create`
+
+        FIXME
+        When the next big release version to publish, this method should be
+        overridden `get_or_create`
+
+        :param kwargs: fields names and proper value types
+        :type kwargs: Any
+        :return: returned or created Model and a flag to check it's new
+        :rtype: Model
+        :rtype: bool
+        """
+        try:
+            return await self.get(*args, **kwargs), False
+        except NoMatch:
+            return await self.create(**kwargs), True
+
     async def update_or_create(self, **kwargs: Any) -> "T":
         """
         Updates the model, or in case there is no match in database creates a new one.

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -1,0 +1,51 @@
+import pytest
+
+import databases
+import ormar
+import sqlalchemy
+
+from tests.settings import DATABASE_URL
+
+
+database = databases.Database(DATABASE_URL, force_rollback=True)
+metadata = sqlalchemy.MetaData()
+
+
+class ToDo(ormar.Model):
+    class Meta:
+        tablename = "todos"
+        metadata = metadata
+        database = database
+        debug = True
+
+    id: int = ormar.Integer(primary_key=True)
+
+
+class Book(ormar.Model):
+    class Meta:
+        tablename = "book"
+        metadata = metadata
+        database = database
+
+    id: int = ormar.Integer(primary_key=True)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def create_test_database():
+    engine = sqlalchemy.create_engine(DATABASE_URL)
+    metadata.drop_all(engine)
+    metadata.create_all(engine)
+    yield
+    metadata.drop_all(engine)
+
+
+@pytest.mark.asyncio
+async def test_debug_sql(capfd):
+    async with database:
+        await ToDo.objects.get_or_none(id=1)
+        out, _ = capfd.readouterr()
+        assert out
+
+        await Book.objects.get_or_none(id=1)
+        out, _ = capfd.readouterr()
+        assert not out

--- a/tests/test_queries/test_queryset_level_methods.py
+++ b/tests/test_queries/test_queryset_level_methods.py
@@ -167,6 +167,31 @@ async def test_get_or_create():
 
 
 @pytest.mark.asyncio
+async def test_find_or_create():
+    async with database:
+        tom, is_new = await Book.objects.find_or_create(
+            title="Volume I", author="Anonymous", genre="Fiction"
+        )
+        assert await Book.objects.count() == 1
+        assert is_new
+
+        book, is_new = await Book.objects.find_or_create(
+            title="Volume I", author="Anonymous", genre="Fiction"
+        )
+        assert book == tom
+        assert not is_new
+        assert await Book.objects.count() == 1
+
+        assert await Book.objects.create(
+            title="Volume I", author="Anonymous", genre="Fiction"
+        )
+        with pytest.raises(ormar.exceptions.MultipleMatches):
+            await Book.objects.find_or_create(
+                title="Volume I", author="Anonymous", genre="Fiction"
+            )
+
+
+@pytest.mark.asyncio
 async def test_update_or_create():
     async with database:
         tom = await Book.objects.update_or_create(


### PR DESCRIPTION
Should be define the new method to solve #386 , until the next big release to publish and remove this method.

BTW in discussions,  the QA:

How to define the `queryset` like that.

```
db.session.query(A,B).filter(A.aid == B.bid)
```