### PR TITLE
exclude null fields in _construct_relations

### DIFF
--- a/ormar/models/model_row.py
+++ b/ormar/models/model_row.py
@@ -101,7 +101,7 @@ class ModelRow(NewBaseModel):
             item["__excluded__"] = cls.get_names_to_exclude(
                 excludable=excludable, alias=table_prefix
             )
-            instance = cast("Model", cls(**item))
+            instance = cast("Model", cls.construct(**item))
             instance.set_save_status(True)
         return instance
 

--- a/ormar/models/model_row.py
+++ b/ormar/models/model_row.py
@@ -101,7 +101,7 @@ class ModelRow(NewBaseModel):
             item["__excluded__"] = cls.get_names_to_exclude(
                 excludable=excludable, alias=table_prefix
             )
-            instance = cast("Model", cls.construct(**item))
+            instance = cast("Model", cls(**item))
             instance.set_save_status(True)
         return instance
 

--- a/ormar/models/newbasemodel.py
+++ b/ormar/models/newbasemodel.py
@@ -859,6 +859,7 @@ class NewBaseModel(pydantic.BaseModel, ModelTableProxy, metaclass=ModelMetaclass
             relation_value = [
                 relation_field.expand_relationship(x, model, to_register=False)
                 for x in value_to_set
+                if x is not None
             ]
 
             for child in relation_value:

--- a/ormar/models/newbasemodel.py
+++ b/ormar/models/newbasemodel.py
@@ -859,7 +859,6 @@ class NewBaseModel(pydantic.BaseModel, ModelTableProxy, metaclass=ModelMetaclass
             relation_value = [
                 relation_field.expand_relationship(x, model, to_register=False)
                 for x in value_to_set
-                if x is not None
             ]
 
             for child in relation_value:


### PR DESCRIPTION
In the method `NewBaseModel._construct_relations` if some relations are null, `expand_relationship` will return `None`. This `None` values will cause the following `AttributeError` when they are passed to `model._orm.add` as `parent`

```
ormar/relations/relation_manager.py", in add
    parent_relation = parent._orm._get(child_name)
AttributeError: 'NoneType' object has no attribute '_orm'
```