### PR TITLE
Add fk_as_int option to get_pydantic()

### DIFF
--- a/docs/models/methods.md
+++ b/docs/models/methods.md
@@ -305,13 +305,22 @@ Of course the end result is a string with json representation and not a dictiona
 
 ## get_pydantic
 
-`get_pydantic(include: Union[Set, Dict] = None, exclude: Union[Set, Dict] = None)`
+`get_pydantic(include: Union[Set, Dict] = None, exclude: Union[Set, Dict] = None, fk_as_int: Union[Set, Dict] = None)`
 
 This method allows you to generate `pydantic` models from your ormar models without you needing to retype all the fields.
 
 Note that if you have nested models, it **will generate whole tree of pydantic models for you!**
 
 Moreover, you can pass `exclude` and/or `include` parameters to keep only the fields that you want to, including in nested models.
+
+If you only want an ID instead of a nested model representation for a related field, add it to the `fk_as_int` parameter. 
+
+!!!Note
+        It is currently only possible to convert models nested once, meaning they must be directly related to a model that is in turn directly related to the model that `get_pydantic` got called on.
+        E.g. if you have a `User` model that has an FK to a `Person` model which in turn has an FK to a `Nation` model, you can have the full Person model (but in it the Nation FK instead of the full Nation model) in the resulting pydantic model like this: 
+        ```python
+        User.get_pdyantic(fk_as_int={"person__nation"})
+        ```
 
 That means that this way you can effortlessly create pydantic models for requests and responses in `fastapi`.
 

--- a/ormar/models/mixins/pydantic_mixin.py
+++ b/ormar/models/mixins/pydantic_mixin.py
@@ -120,19 +120,26 @@ class PydanticMixin(RelationMixin):
         field = cls.Meta.model_fields[name]
         target: Any = None
         if field.is_relation and name in relation_map:  # type: ignore
-            if fk_as_int and name in fk_as_int and not isinstance(fk_as_int[name], Dict):  # type: ignore
-                target = pydantic.PositiveInt
+            if fk_as_int and name in fk_as_int:
+                if not isinstance(fk_as_int[name], Dict):  # type: ignore
+                    target = pydantic.PositiveInt
 
-            else:
-                if fk_as_int and name in fk_as_int and isinstance(fk_as_int[name], Dict):  # type: ignore
+                else:
                     current_level = fk_as_int[name]  # type: ignore
                     fk_as_int.update(current_level)
                     fk_as_int.pop(name)  # type: ignore
-
+                    target = field.to._convert_ormar_to_pydantic(
+                        include=cls._skip_ellipsis(include, name),
+                        exclude=cls._skip_ellipsis(exclude, name),
+                        fk_as_int=fk_as_int,
+                        relation_map=cls._skip_ellipsis(
+                            relation_map, name, default_return=dict()
+                        ),
+                    )
+            else:
                 target = field.to._convert_ormar_to_pydantic(
                     include=cls._skip_ellipsis(include, name),
                     exclude=cls._skip_ellipsis(exclude, name),
-                    fk_as_int=fk_as_int,  # type: ignore
                     relation_map=cls._skip_ellipsis(
                         relation_map, name, default_return=dict()
                     ),

--- a/tests/test_fastapi/test_excludes_with_get_pydantic.py
+++ b/tests/test_fastapi/test_excludes_with_get_pydantic.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from starlette.testclient import TestClient
 
 from tests.settings import DATABASE_URL
-from tests.test_inheritance_and_pydantic_generation.test_geting_pydantic_models import (
+from tests.test_inheritance_and_pydantic_generation.test_getting_pydantic_models import (
     Category,
     SelfRef,
     database,

--- a/tests/test_inheritance_and_pydantic_generation/test_getting_pydantic_models.py
+++ b/tests/test_inheritance_and_pydantic_generation/test_getting_pydantic_models.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 import databases
 import pydantic
 import sqlalchemy
-from pydantic import ConstrainedStr
+from pydantic import ConstrainedStr, PositiveInt
 from pydantic.typing import ForwardRef
 
 import ormar
@@ -165,6 +165,15 @@ def test_getting_pydantic_model_exclude_dict():
     PydanticCategory = PydanticItem.__fields__["category"].type_
     assert len(PydanticCategory.__fields__) == 1
     assert "name" not in PydanticCategory.__fields__
+
+
+def test_getting_pydantic_model_fk_as_int():
+    PydanticItem = Item.get_pydantic(
+        include={"category", "name"}, fk_as_int={"category", "name"}
+    )
+    assert len(PydanticItem.__fields__) == 2
+    assert PydanticItem.__fields__["category"].type_ == PositiveInt
+    assert PydanticItem.__fields__["name"].type_ != PositiveInt
 
 
 def test_getting_pydantic_model_self_ref():

--- a/tests/test_inheritance_and_pydantic_generation/test_getting_pydantic_models.py
+++ b/tests/test_inheritance_and_pydantic_generation/test_getting_pydantic_models.py
@@ -7,6 +7,7 @@ from pydantic import ConstrainedStr, PositiveInt
 from pydantic.typing import ForwardRef
 
 import ormar
+from ormar.fields.foreign_key import ForeignKey
 from tests.settings import DATABASE_URL
 
 metadata = sqlalchemy.MetaData()
@@ -45,6 +46,24 @@ class Item(ormar.Model):
     id: int = ormar.Integer(primary_key=True)
     name: str = ormar.String(max_length=100, default="test")
     category: Optional[Category] = ormar.ForeignKey(Category, nullable=True)
+
+
+class OrderPosition(ormar.Model):
+    class Meta(BaseMeta):
+        pass
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+    item: Optional[Item] = ormar.ForeignKey(Item, skip_reverse=True)
+
+
+class Order(ormar.Model):
+    class Meta(BaseMeta):
+        pass
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+    position: Optional[OrderPosition] = ForeignKey(OrderPosition)
 
 
 class MutualA(ormar.Model):
@@ -174,6 +193,16 @@ def test_getting_pydantic_model_fk_as_int():
     assert len(PydanticItem.__fields__) == 2
     assert PydanticItem.__fields__["category"].type_ == PositiveInt
     assert PydanticItem.__fields__["name"].type_ != PositiveInt
+
+
+def test_getting_pydantic_model_nested_fk_as_int():
+    PydanticOrder = Order.get_pydantic(
+        include={"name", "position"}, fk_as_int={"position__item"}
+    )
+    assert len(PydanticOrder.__fields__) == 2
+    PydanticPosition = PydanticOrder.__fields__["position"].type_
+    assert len(PydanticPosition.__fields__) == 3
+    assert PydanticPosition.__fields__["item"].type_ == PositiveInt
 
 
 def test_getting_pydantic_model_self_ref():


### PR DESCRIPTION
This allows to create pydantic models that contain the FK ID instead of the full related model for each field specified in `fk_as_int`. To see why this can be useful, check #343. 

Unfortunately I didn't manage to allow for more than one level of nesting in the given dict/set, meaning one can only skip the conversion of a directly related model, not an indirectly related one. A more concrete example of this caveat has been added to the docs.