### PR TITLE
Update poetry version

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -49,7 +49,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install poetry==1.1.11
+        python -m pip install poetry==1.3.2
         poetry install --extras "all"
       env:
         POETRY_VIRTUALENVS_CREATE: false


### PR DESCRIPTION
Update poetry version as old version of poetry is causing tests to fail

```
  at /opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/poetry/packages/locker.py:482 in _get_lock_data
      478│                 "Upgrade Poetry to ensure the lock file is read properly or, alternatively, "
      479│                 "regenerate the lock file with the `poetry lock` command."
      480│             )
      481│         elif not lock_version_allowed:
    → 482│             raise RuntimeError(
      483│                 "The lock file is not compatible with the current version of Poetry.\n"
      484│                 "Upgrade Poetry to be able to read the lock file or, alternatively, "
      485│                 "regenerate the lock file with the `poetry lock` command."
      486│             )
Error: Process completed with exit code 1.
```