### PR TITLE
docs: fix foreign key bullet list formatting

### DIFF
--- a/docs/relations/foreign-key.md
+++ b/docs/relations/foreign-key.md
@@ -32,19 +32,21 @@ Reverse relation exposes API to manage related objects also from parent side.
 
 ### Skipping reverse relation
 
-If you are sure you don't want the reverse relation you can use `skip_reverse=True` 
+If you are sure you don't want the reverse relation you can use `skip_reverse=True`
 flag of the `ForeignKey`.
 
-  If you set `skip_reverse` flag internally the field is still registered on the other 
-  side of the relationship so you can:
-  * `filter` by related models fields from reverse model
-  * `order_by` by related models fields from reverse model 
+If you set `skip_reverse` flag internally the field is still registered on the other
+side of the relationship so you can:
+
+* `filter` by related models fields from reverse model
+* `order_by` by related models fields from reverse model
   
-  But you cannot:
-  * access the related field from reverse model with `related_name`
-  * even if you `select_related` from reverse side of the model the returned models won't be populated in reversed instance (the join is not prevented so you still can `filter` and `order_by` over the relation)
-  * the relation won't be populated in `dict()` and `json()`
-  * you cannot pass the nested related objects when populating from dictionary or json (also through `fastapi`). It will be either ignored or error will be raised depending on `extra` setting in pydantic `Config`.
+But you cannot:
+
+* Access the related field from reverse model with `related_name`
+* Even if you `select_related` from reverse side of the model the returned models won't be populated in reversed instance (the join is not prevented so you still can `filter` and `order_by` over the relation)
+* The relation won't be populated in `dict()` and `json()`
+* You cannot pass the nested related objects when populating from dictionary or json (also through `fastapi`). It will be either ignored or error will be raised depending on `extra` setting in pydantic `Config`.
 
 Example:
 


### PR DESCRIPTION
Current documentation has a malformed bullet list:
![image](https://user-images.githubusercontent.com/13562529/236679822-d437f8c3-57c8-47d4-8f5a-a4dcf375a75e.png)
This PR fixes the Markdown formatting so the bullet list displays properly. Screenshot from docs in my dev environment:
![image](https://user-images.githubusercontent.com/13562529/236679845-4759b252-3cfa-4bf9-aa7d-2807d12c421d.png)
