### PR TITLE
fix: test_initializing_models failing

### DIFF
--- a/benchmarks/test_benchmark_init.py
+++ b/benchmarks/test_benchmark_init.py
@@ -21,7 +21,7 @@ async def test_initializing_models(aio_benchmark, num_models: int):
         ]
         assert len(authors) == num_models
 
-    await initialize_models(num_models)
+    initialize_models(num_models)
 
 
 @pytest.mark.parametrize("num_models", [10, 20, 40])

--- a/ormar/queryset/actions/order_action.py
+++ b/ormar/queryset/actions/order_action.py
@@ -78,14 +78,17 @@ class OrderAction(QueryAction):
         :return: complied and escaped clause
         :rtype: sqlalchemy.sql.elements.TextClause
         """
+        dialect = self.target_model.Meta.database._backend._dialect
+        quoter = dialect.identifier_preparer.quote
         prefix = f"{self.table_prefix}_" if self.table_prefix else ""
         table_name = self.table.name
         field_name = self.field_alias
         if not prefix:
-            dialect = self.target_model.Meta.database._backend._dialect
-            table_name = dialect.identifier_preparer.quote(table_name)
-            field_name = dialect.identifier_preparer.quote(field_name)
-        return text(f"{prefix}{table_name}" f".{field_name} {self.direction}")
+            table_name = quoter(table_name)
+        else:
+            table_name = quoter(f"{prefix}{table_name}")
+        field_name = quoter(field_name)
+        return text(f"{table_name}.{field_name} {self.direction}")
 
     def _split_value_into_parts(self, order_str: str) -> None:
         if order_str.startswith("-"):

--- a/tests/test_model_definition/test_field_quoting.py
+++ b/tests/test_model_definition/test_field_quoting.py
@@ -1,0 +1,75 @@
+import asyncio
+from typing import Optional
+
+import databases
+import pytest
+import sqlalchemy
+
+import ormar
+from tests.settings import DATABASE_URL
+
+database = databases.Database(DATABASE_URL, force_rollback=True)
+metadata = sqlalchemy.MetaData()
+
+
+class SchoolClass(ormar.Model):
+    class Meta:
+        tablename = "app.schoolclasses"
+        metadata = metadata
+        database = database
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+
+
+class Category(ormar.Model):
+    class Meta:
+        tablename = "app.categories"
+        metadata = metadata
+        database = database
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+
+
+class Student(ormar.Model):
+    class Meta:
+        tablename = "app.students"
+        metadata = metadata
+        database = database
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+    schoolclass: Optional[SchoolClass] = ormar.ForeignKey(SchoolClass, related_name="students")
+    category: Optional[Category] = ormar.ForeignKey(Category, nullable=True, related_name="students")
+
+
+@pytest.fixture(autouse=True, scope="module")
+def create_test_database():
+    engine = sqlalchemy.create_engine(DATABASE_URL)
+    metadata.drop_all(engine)
+    metadata.create_all(engine)
+    yield
+    metadata.drop_all(engine)
+
+
+async def create_data():
+    class1 = await SchoolClass.objects.create(name="Math")
+    class2 = await SchoolClass.objects.create(name="Logic")
+    category = await Category.objects.create(name="Foreign")
+    category2 = await Category.objects.create(name="Domestic")
+    await Student.objects.create(name="Jane", category=category, schoolclass=class1)
+    await Student.objects.create(name="Judy", category=category2, schoolclass=class1)
+    await Student.objects.create(name="Jack", category=category2, schoolclass=class2)
+
+
+@pytest.mark.asyncio
+async def test_quotes_left_join():
+    async with database:
+        async with database.transaction(force_rollback=True):
+            await create_data()
+            students = await Student.objects.filter(
+                (Student.schoolclass.name == "Math") | (Student.category.name == "Foreign")
+            ).all()
+            for student in students:
+                assert student.schoolclass.name == "Math" or student.category.name == "Foreign"


### PR DESCRIPTION
The `test_initializing_models` test in `test_benchmark_init.py` incorrectly awaits the wrapped `initialize_models` function. This fixes that and brings us back to 100% passing tests in master.