### PR TITLE
fix: test_initializing_models failing

### DIFF
--- a/benchmarks/test_benchmark_init.py
+++ b/benchmarks/test_benchmark_init.py
@@ -21,7 +21,7 @@ async def test_initializing_models(aio_benchmark, num_models: int):
         ]
         assert len(authors) == num_models
 
-    await initialize_models(num_models)
+    initialize_models(num_models)
 
 
 @pytest.mark.parametrize("num_models", [10, 20, 40])


### PR DESCRIPTION
The `test_initializing_models` test in `test_benchmark_init.py` incorrectly awaits the wrapped `initialize_models` function. This fixes that and brings us back to 100% passing tests in master.