### PR TITLE
Pass ForeignKey kwargs to BaseField

### DIFF
--- a/ormar/fields/foreign_key.py
+++ b/ormar/fields/foreign_key.py
@@ -313,6 +313,7 @@ def ForeignKey(  # type: ignore # noqa CFQ002
         related_orders_by=related_orders_by,
         skip_reverse=skip_reverse,
         skip_field=skip_field,
+        **kwargs,
     )
 
     Field = type("ForeignKey", (ForeignKeyField, BaseField), {})

--- a/ormar/fields/many_to_many.py
+++ b/ormar/fields/many_to_many.py
@@ -185,6 +185,7 @@ def ManyToMany(  # type: ignore
         through_reverse_foreign_key_name=through_reverse_foreign_key_name,
         through_relation_nullable=through_relation_nullable,
         through_reverse_relation_nullable=through_reverse_relation_nullable,
+        **kwargs,
     )
 
     Field = type("ManyToMany", (ManyToManyField, BaseField), {})

--- a/tests/test_model_definition/test_setting_comments_in_db.py
+++ b/tests/test_model_definition/test_setting_comments_in_db.py
@@ -8,11 +8,27 @@ from tests.settings import create_config
 base_ormar_config = create_config()
 
 
+class Author(Model):
+    ormar_config = base_ormar_config.copy(tablename="comment_authors")
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=80)
+
+
+class Tag(Model):
+    ormar_config = base_ormar_config.copy(tablename="comment_tags")
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=40)
+
+
 class Comment(Model):
     ormar_config = base_ormar_config.copy(tablename="comments")
 
     test: int = ormar.Integer(primary_key=True, comment="primary key of comments")
     test_string: str = ormar.String(max_length=250, comment="test that it works")
+    author: Author = ormar.ForeignKey(Author, comment="author of the comment")
+    tags = ormar.ManyToMany(Tag, comment="tags attached to the comment")
 
 
 create_test_database = init_tests(base_ormar_config)
@@ -23,3 +39,22 @@ async def test_comments_are_set_in_db():
     columns = Comment.ormar_config.table.c
     for c in columns:
         assert c.comment == Comment.ormar_config.model_fields[c.name].comment
+
+
+def test_foreign_key_comment_reaches_field_and_column():
+    assert (
+        Comment.ormar_config.model_fields["author"].comment == "author of the comment"
+    )
+    assert Comment.ormar_config.table.c.author.comment == "author of the comment"
+
+
+def test_many_to_many_comment_stored_on_field():
+    # M2M has no column on the owner model's table and does not propagate the
+    # comment to the through model's columns, so the field attribute is the
+    # only observable side effect.
+    assert (
+        Comment.ormar_config.model_fields["tags"].comment
+        == "tags attached to the comment"
+    )
+    through = Comment.ormar_config.model_fields["tags"].through
+    assert all(c.comment is None for c in through.ormar_config.table.c)


### PR DESCRIPTION
I want to add a comment on the ForeignKey:

```
class MyModel(ormar.Model):
    model_two: MyAnotherModel = ForeignKey(
        MyAnotherModel,
        ...
        comment="my super comment",
    )

```
And this does not work due to the fact that the kwargs are not passed to the ForeignKeyField, however, according to the documentation, it should:

> :param kwargs: all other args to be populated by BaseField

The proposed code fixes this problem. Could you take a look at it, please?


