### PR TITLE
release 0.20.2

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,20 @@
 # Release notes
 
+## 0.20.2
+
+### 🐛 Fixes
+
+* Fix mutable default argument in translate list to dict  - thanks @cadlagtrader [#1382](https://github.com/collerek/ormar/pull/1382)
+* Fix fastapi docs - thanks @inktrap [#1362](https://github.com/collerek/ormar/pull/1362)
+* Fix clashing many to many fields names [#1407](https://github.com/collerek/ormar/pull/1407)
+
+### 💬 Other
+* Add official support for python 3.12 - thanks @ChristopherMacGown [#1395](https://github.com/collerek/ormar/pull/1395)
+* Unpin pydantic allowing pydantic versions <2.9.0 - thanks @camillol [#1388](https://github.com/collerek/ormar/pull/1388)
+
+
+# Release notes
+
 ## 0.20.1
 
 ### ✨ Breaking changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ormar"
 
 [tool.poetry]
 name = "ormar"
-version = "0.20.1"
+version = "0.20.2"
 description = "An async ORM with fastapi in mind and pydantic validation."
 authors = ["Radosław Drążkiewicz <collerek@gmail.com>"]
 license = "MIT"
@@ -36,6 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
 ]
 


### PR DESCRIPTION
# Release notes

## 0.20.2

### 🐛 Fixes

* Fix mutable default argument in translate list to dict  - thanks @cadlagtrader [#1382](https://github.com/collerek/ormar/pull/1382)
* Fix fastapi docs - thanks @inktrap [#1362](https://github.com/collerek/ormar/pull/1362)
* Fix clashing many to many fields names [#1407](https://github.com/collerek/ormar/pull/1407)

### 💬 Other
* Add official support for python 3.12 - thanks @ChristopherMacGown [#1395](https://github.com/collerek/ormar/pull/1395)
* Unpin pydantic allowing pydantic versions <2.9.0 - thanks @camillol [#1388](https://github.com/collerek/ormar/pull/1388)
