### PR TITLE
fix: run standalone queries under AUTOCOMMIT isolation (#1629)

### DIFF
--- a/ormar/databases/connection.py
+++ b/ormar/databases/connection.py
@@ -38,6 +38,7 @@ class DatabaseConnection:
             options["max_overflow"] = 10
         self._options = options
         self._engine: Optional[AsyncEngine] = None
+        self._autocommit_engine: Optional[AsyncEngine] = None
 
         self._global_transaction: Optional[Transaction] = None
 
@@ -45,6 +46,14 @@ class DatabaseConnection:
         """Connect to the database by creating the async engine."""
         if self._engine is None:
             self._engine = create_async_engine(self._url, **self._options)
+            # View of the same engine/pool in AUTOCOMMIT mode. Standalone
+            # queries use this to avoid a BEGIN/COMMIT round-trip per call,
+            # matching legacy `databases`-library semantics. Explicit
+            # Transactions keep using ``self._engine`` so BEGIN / SAVEPOINT
+            # still work.
+            self._autocommit_engine = self._engine.execution_options(
+                isolation_level="AUTOCOMMIT"
+            )
 
             # Set up SQLite foreign keys pragma if using SQLite
             if self._engine.dialect.name == "sqlite":  # pragma: nocover
@@ -75,6 +84,7 @@ class DatabaseConnection:
 
             await self._engine.dispose()
             self._engine = None
+            self._autocommit_engine = None
 
     @property
     def is_connected(self) -> bool:
@@ -119,10 +129,19 @@ class DatabaseConnection:
         return Transaction(self, force_rollback=force_rollback)
 
     @asynccontextmanager
-    async def get_query_executor(self) -> AsyncIterator[QueryExecutor]:
+    async def get_query_executor(
+        self, *, transactional: bool = False
+    ) -> AsyncIterator[QueryExecutor]:
         """
         Get connection, reusing transaction connection if in transaction.
 
+        :param transactional: If True, open an explicit transaction for the
+            scope of the executor. Use for server-side cursors (``iterate``)
+            and multi-row ``execute_many`` batches, which need a real
+            transaction either because AUTOCOMMIT would commit each row
+            separately or because the driver (asyncpg) requires a
+            transaction for streaming.
+        :type transactional: bool
         :return: QueryExecutor wrapping a connection
         :rtype: QueryExecutor
         """
@@ -130,11 +149,18 @@ class DatabaseConnection:
         if trans_conn is not None:
             # Inside a transaction - reuse the transaction's connection
             yield QueryExecutor(trans_conn)
-        else:
-            # Outside transaction: connect() + commit().
-            async with self.engine.connect() as conn:
+        elif transactional:
+            async with self.transaction():
+                conn = self.get_transaction_connection()
+                assert conn is not None
                 yield QueryExecutor(conn)
-                await conn.commit()
+        else:
+            # Outside transaction: use AUTOCOMMIT view so each statement
+            # commits at the driver level with no extra BEGIN/COMMIT
+            # round-trip.
+            assert self._autocommit_engine is not None
+            async with self._autocommit_engine.connect() as conn:
+                yield QueryExecutor(conn)
 
     def get_transaction_connection(self) -> Optional[AsyncConnection]:
         """Get the current transaction connection if in a transaction."""

--- a/ormar/databases/transaction.py
+++ b/ormar/databases/transaction.py
@@ -40,7 +40,10 @@ class Transaction:
         """Enter transaction context."""
         self._depth = _transaction_depth.get()
 
-        # If this is the outermost transaction, get a new connection
+        # If this is the outermost transaction, get a new connection.
+        # This uses the main engine (not the AUTOCOMMIT view used by
+        # standalone queries) so ``connection.begin()`` and the nested
+        # ``begin_nested()`` savepoints below both work.
         if self._depth == 0:
             self._connection = await self._database.engine.connect().__aenter__()
             self._database.set_transaction_connection(self._connection)

--- a/ormar/queryset/queryset.py
+++ b/ormar/queryset/queryset.py
@@ -1113,7 +1113,11 @@ class QuerySet(Generic[T]):
         last_primary_key = None
         pk_alias = self.model.get_column_alias(self.model_config.pkname)
 
-        async with self.model_config.database.get_query_executor() as executor:
+        # Server-side cursor (asyncpg/aiomysql) requires an open transaction,
+        # which AUTOCOMMIT does not provide.
+        async with self.model_config.database.get_query_executor(
+            transactional=True
+        ) as executor:
             async for row in executor.iterate(expr):
                 current_primary_key = row[pk_alias]
                 if last_primary_key == current_primary_key or last_primary_key is None:
@@ -1260,7 +1264,11 @@ class QuerySet(Generic[T]):
         # databases bind params only where query is passed as string
         # otherwise it just passes all data to values and results in unconsumed columns
         expr = str(expr)  # type: ignore
-        async with self.model_config.database.get_query_executor() as executor:
+        # Multi-row execute_many: run in an explicit transaction so all rows
+        # share a single COMMIT instead of one per row under AUTOCOMMIT.
+        async with self.model_config.database.get_query_executor(
+            transactional=True
+        ) as executor:
             await executor.execute_many(expr, ready_objects)
 
         for obj in objects:

--- a/tests/test_databases/test_connection.py
+++ b/tests/test_databases/test_connection.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy import text
+from sqlalchemy import event, text
 
 import ormar
 from ormar.databases.connection import DatabaseConnection
@@ -147,3 +147,82 @@ async def test_force_rollback_cascades():
 
         teams = await Team.objects.all()
         assert len(teams) == 0
+
+
+@pytest.mark.asyncio
+async def test_standalone_query_uses_autocommit():
+    """Standalone CRUD must not wrap each statement in BEGIN/COMMIT.
+
+    The old code path held a real transaction around every call; this test
+    pins the replacement behavior so future refactors don't silently reintroduce
+    the per-query commit overhead (see discussion #1629).
+    """
+    seen_autocommit: list[bool] = []
+
+    def capture(conn, cursor, statement, parameters, context, executemany):
+        if "teams" not in statement.lower():
+            return
+        seen_autocommit.append(
+            conn.get_execution_options().get("isolation_level") == "AUTOCOMMIT"
+        )
+
+    async with base_ormar_config.database:
+        event.listen(
+            base_ormar_config.database.engine.sync_engine,
+            "before_cursor_execute",
+            capture,
+        )
+        try:
+            await Team.objects.create(name="Standalone")
+            await Team.objects.get(name="Standalone")
+
+            async with base_ormar_config.database.transaction():
+                await Team.objects.create(name="InsideTransaction")
+                await Team.objects.get(name="InsideTransaction")
+        finally:
+            event.remove(
+                base_ormar_config.database.engine.sync_engine,
+                "before_cursor_execute",
+                capture,
+            )
+
+    # First two statements were standalone → must have run under AUTOCOMMIT.
+    # Last two were inside an explicit transaction → must NOT have.
+    assert seen_autocommit[:2] == [True, True]
+    assert all(flag is False for flag in seen_autocommit[2:])
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_is_atomic_under_autocommit():
+    """``bulk_update`` must run inside a transaction so that if anything
+    after the write raises, the write is rolled back.
+
+    The mock below lets the real ``execute_many`` run first (so the rows
+    actually get updated inside the open transaction) and only then raises.
+    If the transaction wrapper around ``execute_many`` were removed,
+    AUTOCOMMIT would already have persisted the renames and the post-update
+    assertion would see ``renamed-*`` instead of the original names.
+    """
+    async with base_ormar_config.database:
+        seeded = [await Team.objects.create(name=f"bulk-{n}") for n in "XYZ"]
+        ids = [t.id for t in seeded]
+        for idx, team in enumerate(seeded):
+            team.name = f"renamed-{idx}"
+
+        from ormar.databases.query_executor import QueryExecutor
+
+        orig = QueryExecutor.execute_many
+
+        async def execute_then_raise(self, query, values):
+            await orig(self, query, values)
+            raise RuntimeError("boom")
+
+        QueryExecutor.execute_many = execute_then_raise  # type: ignore[assignment]
+        try:
+            with pytest.raises(RuntimeError, match="boom"):
+                await Team.objects.bulk_update(seeded)
+        finally:
+            QueryExecutor.execute_many = orig  # type: ignore[assignment]
+
+        reloaded = await Team.objects.filter(id__in=ids).all()
+        assert {t.name for t in reloaded} == {"bulk-X", "bulk-Y", "bulk-Z"}

--- a/tests/test_databases/test_connection.py
+++ b/tests/test_databases/test_connection.py
@@ -160,8 +160,6 @@ async def test_standalone_query_uses_autocommit():
     seen_autocommit: list[bool] = []
 
     def capture(conn, cursor, statement, parameters, context, executemany):
-        if "teams" not in statement.lower():
-            return
         seen_autocommit.append(
             conn.get_execution_options().get("isolation_level") == "AUTOCOMMIT"
         )


### PR DESCRIPTION
run standalone queries under AUTOCOMMIT isolation (#1629), restore the performance degradation from <= 0.21 with additional boost from other optimizations