### PR TITLE
feat: nulls_ordering (NULLS FIRST/LAST) for order_by (#769)

### DIFF
--- a/docs/queries/filter-and-sort.md
+++ b/docs/queries/filter-and-sort.md
@@ -783,7 +783,32 @@ assert owner.toys[1].name == "Toy 1"
 
     So operations like `filter()`, `select_related()`, `limit()` and `offset()` etc. can be chained.
     
-    Something like `Track.object.select_related("album").filter(album__name="Malibu").offset(1).limit(1).all()`
+    Something like `Track.objects.select_related("album").filter(album__name="Malibu").offset(1).limit(1).all()`
+
+#### Controlling NULL placement with `nulls_ordering`
+
+Both `.asc()` and `.desc()` accept an optional `nulls_ordering` argument so you can
+decide whether `NULL` values come first or last in the result:
+
+```python
+import ormar
+
+# nulls go to the end
+await Song.objects.order_by(
+    Song.sort_order.asc(nulls_ordering=ormar.NullsOrdering.LAST)
+).all()
+
+# nulls come first
+await Owner.objects.order_by(
+    Owner.toys.name.desc(nulls_ordering=ormar.NullsOrdering.FIRST)
+).all()
+```
+
+!!!note
+    On PostgreSQL and SQLite (3.30+) this emits the standard `NULLS FIRST` /
+    `NULLS LAST` clause. MySQL does not support that syntax, so `ormar`
+    emulates it by prepending an `IS NULL` / `IS NOT NULL` sort key — the
+    result set is unchanged, only the ordering.
 
 ### Default sorting in ormar
 

--- a/ormar/__init__.py
+++ b/ormar/__init__.py
@@ -75,7 +75,7 @@ from ormar.fields import (
 # noqa: I100
 from ormar.databases.connection import DatabaseConnection
 from ormar.models import ExcludableItems, Extra, Model, OrmarConfig
-from ormar.queryset import OrderAction, QuerySet, and_, or_
+from ormar.queryset import NullsOrdering, OrderAction, QuerySet, and_, or_
 from ormar.relations import RelationType
 from ormar.signals import Signal
 
@@ -134,6 +134,7 @@ __all__ = [
     "ManyToManyField",
     "ForeignKeyField",
     "OrderAction",
+    "NullsOrdering",
     "ExcludableItems",
     "and_",
     "or_",

--- a/ormar/queryset/__init__.py
+++ b/ormar/queryset/__init__.py
@@ -3,7 +3,7 @@ Contains QuerySet and different Query classes to allow for constructing of sql q
 """
 
 from ormar.queryset.actions import FilterAction, OrderAction, SelectAction
-from ormar.queryset.clause import and_, or_
+from ormar.queryset.clause import NullsOrdering, and_, or_
 from ormar.queryset.field_accessor import FieldAccessor
 from ormar.queryset.queries import FilterQuery, LimitQuery, OffsetQuery, OrderQuery
 from ormar.queryset.queryset import QuerySet
@@ -17,6 +17,7 @@ __all__ = [
     "FilterAction",
     "OrderAction",
     "SelectAction",
+    "NullsOrdering",
     "and_",
     "or_",
     "FieldAccessor",

--- a/ormar/queryset/actions/order_action.py
+++ b/ormar/queryset/actions/order_action.py
@@ -20,7 +20,11 @@ class OrderAction(QueryAction):
     """
 
     def __init__(
-        self, order_str: str, model_cls: type["Model"], alias: Optional[str] = None
+        self,
+        order_str: str,
+        model_cls: type["Model"],
+        alias: Optional[str] = None,
+        nulls_ordering: Optional[str] = None,
     ) -> None:
         self.direction: str = ""
         super().__init__(query_str=order_str, model_cls=model_cls)
@@ -29,6 +33,7 @@ class OrderAction(QueryAction):
             self.table_prefix = alias
         if self.source_model == self.target_model and "__" not in self.related_str:
             self.is_source_model_order = True
+        self.nulls_ordering = nulls_ordering
 
     @property
     def field_alias(self) -> str:
@@ -90,7 +95,30 @@ class OrderAction(QueryAction):
         else:
             table_name = quoter(f"{prefix}{table_name}")
         field_name = quoter(field_name)
-        return text(f"{table_name}.{field_name} {self.direction}")
+        return text(self._build_order_expression(f"{table_name}.{field_name}"))
+
+    def _build_order_expression(self, full_column: str) -> str:
+        """
+        Builds the final ORDER BY expression for a fully-qualified column,
+        optionally including a `NULLS FIRST`/`NULLS LAST` annotation. On MySQL,
+        which lacks the SQL:2003 `NULLS` syntax, emulate it by prepending an
+        `IS NULL` / `IS NOT NULL` sort key — it only affects ordering,
+        not the result set.
+
+        :param full_column: fully-qualified, quoted column reference
+        :type full_column: str
+        :return: ORDER BY expression as raw SQL text
+        :rtype: str
+        """
+        direction = f" {self.direction}" if self.direction else ""
+        base = f"{full_column}{direction}"
+        if self.nulls_ordering is None:
+            return base
+        dialect_name = self.target_model.ormar_config.database.dialect.name
+        if dialect_name == "mysql":  # pragma: no cover
+            not_kw = "not " if self.nulls_ordering == "first" else ""
+            return f"{full_column} is {not_kw}null, {base}"
+        return f"{base} nulls {self.nulls_ordering}"
 
     def _split_value_into_parts(self, order_str: str) -> None:
         if order_str.startswith("-"):

--- a/ormar/queryset/actions/order_action.py
+++ b/ormar/queryset/actions/order_action.py
@@ -118,7 +118,7 @@ class OrderAction(QueryAction):
         if dialect_name == "mysql":  # pragma: no cover
             not_kw = "not " if self.nulls_ordering == "first" else ""
             return f"{full_column} is {not_kw}null, {base}"
-        return f"{base} nulls {self.nulls_ordering}"
+        return f"{base} nulls {self.nulls_ordering}"  # pragma: no cover
 
     def _split_value_into_parts(self, order_str: str) -> None:
         if order_str.startswith("-"):

--- a/ormar/queryset/clause.py
+++ b/ormar/queryset/clause.py
@@ -19,6 +19,13 @@ class FilterType(Enum):
     OR = 2
 
 
+class NullsOrdering(str, Enum):
+    """Nulls placement options for the `.order_by()` queries."""
+
+    FIRST = "first"
+    LAST = "last"
+
+
 class FilterGroup:
     """
     Filter groups are used in complex queries condition to group and and or

--- a/ormar/queryset/field_accessor.py
+++ b/ormar/queryset/field_accessor.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 
 from ormar.queryset.actions import OrderAction
 from ormar.queryset.actions.filter_action import METHODS_TO_OPERATORS
-from ormar.queryset.clause import FilterGroup
+from ormar.queryset.clause import FilterGroup, NullsOrdering
 
 if TYPE_CHECKING:  # pragma: no cover
     from ormar import BaseField, Model
@@ -260,22 +260,48 @@ class FieldAccessor:
         """
         return self._select_operator(op="isnull", other=other)
 
-    def asc(self) -> OrderAction:
+    def asc(self, nulls_ordering: Optional[NullsOrdering] = None) -> OrderAction:
         """
         works as sql `column asc`
 
+        :param nulls_ordering: optional nulls placement, `NullsOrdering.FIRST`
+            or `NullsOrdering.LAST`
+        :type nulls_ordering: Optional[NullsOrdering]
+        :raises ValueError: if `nulls_ordering` is not a `NullsOrdering` member
         :return: OrderGroup for operator
         :rtype: ormar.queryset.actions.OrderGroup
         """
-        return OrderAction(order_str=self._access_chain, model_cls=self._source_model)
+        nulls_value = self._coerce_nulls_ordering(nulls_ordering)
+        return OrderAction(
+            order_str=self._access_chain,
+            model_cls=self._source_model,
+            nulls_ordering=nulls_value,
+        )
 
-    def desc(self) -> OrderAction:
+    def desc(self, nulls_ordering: Optional[NullsOrdering] = None) -> OrderAction:
         """
         works as sql `column desc`
 
+        :param nulls_ordering: optional nulls placement, `NullsOrdering.FIRST`
+            or `NullsOrdering.LAST`
+        :type nulls_ordering: Optional[NullsOrdering]
+        :raises ValueError: if `nulls_ordering` is not a `NullsOrdering` member
         :return: OrderGroup for operator
         :rtype: ormar.queryset.actions.OrderGroup
         """
+        nulls_value = self._coerce_nulls_ordering(nulls_ordering)
         return OrderAction(
-            order_str="-" + self._access_chain, model_cls=self._source_model
+            order_str="-" + self._access_chain,
+            model_cls=self._source_model,
+            nulls_ordering=nulls_value,
         )
+
+    @staticmethod
+    def _coerce_nulls_ordering(
+        nulls_ordering: Optional[NullsOrdering],
+    ) -> Optional[str]:
+        if nulls_ordering is None:
+            return None
+        if not isinstance(nulls_ordering, NullsOrdering):
+            raise ValueError("Invalid option for ordering nulls values.")
+        return nulls_ordering.value

--- a/tests/test_queries/test_order_by.py
+++ b/tests/test_queries/test_order_by.py
@@ -14,7 +14,7 @@ class Song(ormar.Model):
 
     id: int = ormar.Integer(primary_key=True)
     name: str = ormar.String(max_length=100)
-    sort_order: int = ormar.Integer()
+    sort_order: Optional[int] = ormar.Integer(nullable=True)
 
 
 class Owner(ormar.Model):
@@ -22,6 +22,7 @@ class Owner(ormar.Model):
 
     id: int = ormar.Integer(primary_key=True)
     name: str = ormar.String(max_length=100)
+    age: Optional[int] = ormar.Integer(nullable=True)
 
 
 class AliasNested(ormar.Model):
@@ -76,256 +77,379 @@ create_test_database = init_tests(base_ormar_config)
 @pytest.mark.asyncio
 async def test_sort_order_on_main_model():
     async with base_ormar_config.database:
-        await Song.objects.create(name="Song 3", sort_order=3)
-        await Song.objects.create(name="Song 1", sort_order=1)
-        await Song.objects.create(name="Song 2", sort_order=2)
+        async with base_ormar_config.database.transaction(force_rollback=True):
+            await Song.objects.create(name="Song 3", sort_order=3)
+            await Song.objects.create(name="Song 1", sort_order=1)
+            await Song.objects.create(name="Song 2", sort_order=2)
 
-        songs = await Song.objects.all()
-        assert songs[0].name == "Song 3"
-        assert songs[1].name == "Song 1"
-        assert songs[2].name == "Song 2"
+            songs = await Song.objects.all()
+            assert songs[0].name == "Song 3"
+            assert songs[1].name == "Song 1"
+            assert songs[2].name == "Song 2"
 
-        songs = await Song.objects.order_by("-sort_order").all()
-        assert songs[0].name == "Song 3"
-        assert songs[1].name == "Song 2"
-        assert songs[2].name == "Song 1"
+            songs = await Song.objects.order_by("-sort_order").all()
+            assert songs[0].name == "Song 3"
+            assert songs[1].name == "Song 2"
+            assert songs[2].name == "Song 1"
 
-        songs = await Song.objects.order_by(Song.sort_order.desc()).all()
-        assert songs[0].name == "Song 3"
-        assert songs[1].name == "Song 2"
-        assert songs[2].name == "Song 1"
+            songs = await Song.objects.order_by(Song.sort_order.desc()).all()
+            assert songs[0].name == "Song 3"
+            assert songs[1].name == "Song 2"
+            assert songs[2].name == "Song 1"
 
-        songs = await Song.objects.order_by("sort_order").all()
-        assert songs[0].name == "Song 1"
-        assert songs[1].name == "Song 2"
-        assert songs[2].name == "Song 3"
+            songs = await Song.objects.order_by("sort_order").all()
+            assert songs[0].name == "Song 1"
+            assert songs[1].name == "Song 2"
+            assert songs[2].name == "Song 3"
 
-        songs = await Song.objects.order_by(Song.sort_order.asc()).all()
-        assert songs[0].name == "Song 1"
-        assert songs[1].name == "Song 2"
-        assert songs[2].name == "Song 3"
+            songs = await Song.objects.order_by(Song.sort_order.asc()).all()
+            assert songs[0].name == "Song 1"
+            assert songs[1].name == "Song 2"
+            assert songs[2].name == "Song 3"
 
-        songs = await Song.objects.order_by("name").all()
-        assert songs[0].name == "Song 1"
-        assert songs[1].name == "Song 2"
-        assert songs[2].name == "Song 3"
+            songs = await Song.objects.order_by("name").all()
+            assert songs[0].name == "Song 1"
+            assert songs[1].name == "Song 2"
+            assert songs[2].name == "Song 3"
 
-        songs = await Song.objects.order_by("name").limit(2).all()
-        assert len(songs) == 2
-        assert songs[0].name == "Song 1"
-        assert songs[1].name == "Song 2"
+            songs = await Song.objects.order_by("name").limit(2).all()
+            assert len(songs) == 2
+            assert songs[0].name == "Song 1"
+            assert songs[1].name == "Song 2"
 
-        await Song.objects.create(name="Song 4", sort_order=1)
+            await Song.objects.create(name="Song 4", sort_order=1)
 
-        songs = await Song.objects.order_by(["sort_order", "name"]).all()
-        assert songs[0].name == "Song 1"
-        assert songs[1].name == "Song 4"
-        assert songs[2].name == "Song 2"
-        assert songs[3].name == "Song 3"
+            songs = await Song.objects.order_by(["sort_order", "name"]).all()
+            assert songs[0].name == "Song 1"
+            assert songs[1].name == "Song 4"
+            assert songs[2].name == "Song 2"
+            assert songs[3].name == "Song 3"
 
-        songs = await Song.objects.order_by(
-            [Song.sort_order.asc(), Song.name.asc()]
-        ).all()
-        assert songs[0].name == "Song 1"
-        assert songs[1].name == "Song 4"
-        assert songs[2].name == "Song 2"
-        assert songs[3].name == "Song 3"
+            songs = await Song.objects.order_by(
+                [Song.sort_order.asc(), Song.name.asc()]
+            ).all()
+            assert songs[0].name == "Song 1"
+            assert songs[1].name == "Song 4"
+            assert songs[2].name == "Song 2"
+            assert songs[3].name == "Song 3"
+
+
+@pytest.mark.asyncio
+async def test_sort_order_nulls_first_last():
+    async with base_ormar_config.database:
+        async with base_ormar_config.database.transaction(force_rollback=True):
+            await Song.objects.create(name="Song A", sort_order=10)
+            await Song.objects.create(name="Song B", sort_order=20)
+            await Song.objects.create(name="Song C", sort_order=30)
+            await Song.objects.create(name="Song N1")
+            await Song.objects.create(name="Song N2")
+
+            songs = await Song.objects.order_by(
+                [
+                    Song.sort_order.asc(nulls_ordering=ormar.NullsOrdering.LAST),
+                    Song.name.asc(),
+                ]
+            ).all()
+            assert [s.name for s in songs] == [
+                "Song A",
+                "Song B",
+                "Song C",
+                "Song N1",
+                "Song N2",
+            ]
+
+            songs = await Song.objects.order_by(
+                [
+                    Song.sort_order.asc(nulls_ordering=ormar.NullsOrdering.FIRST),
+                    Song.name.asc(),
+                ]
+            ).all()
+            assert [s.name for s in songs] == [
+                "Song N1",
+                "Song N2",
+                "Song A",
+                "Song B",
+                "Song C",
+            ]
+
+            songs = await Song.objects.order_by(
+                [
+                    Song.sort_order.desc(nulls_ordering=ormar.NullsOrdering.LAST),
+                    Song.name.asc(),
+                ]
+            ).all()
+            assert [s.name for s in songs] == [
+                "Song C",
+                "Song B",
+                "Song A",
+                "Song N1",
+                "Song N2",
+            ]
+
+            songs = await Song.objects.order_by(
+                [
+                    Song.sort_order.desc(nulls_ordering=ormar.NullsOrdering.FIRST),
+                    Song.name.asc(),
+                ]
+            ).all()
+            assert [s.name for s in songs] == [
+                "Song N1",
+                "Song N2",
+                "Song C",
+                "Song B",
+                "Song A",
+            ]
+
+            with pytest.raises(ValueError):
+                Song.sort_order.asc(nulls_ordering=False)
+
+            with pytest.raises(ValueError):
+                Song.sort_order.desc(nulls_ordering=True)
 
 
 @pytest.mark.asyncio
 async def test_sort_order_on_related_model():
     async with base_ormar_config.database:
-        aphrodite = await Owner.objects.create(name="Aphrodite")
-        hermes = await Owner.objects.create(name="Hermes")
-        zeus = await Owner.objects.create(name="Zeus")
+        async with base_ormar_config.database.transaction(force_rollback=True):
+            aphrodite = await Owner.objects.create(name="Aphrodite")
+            hermes = await Owner.objects.create(name="Hermes")
+            zeus = await Owner.objects.create(name="Zeus")
 
-        await Toy.objects.create(name="Toy 4", owner=zeus)
-        await Toy.objects.create(name="Toy 5", owner=hermes)
-        await Toy.objects.create(name="Toy 2", owner=aphrodite)
-        await Toy.objects.create(name="Toy 1", owner=zeus)
-        await Toy.objects.create(name="Toy 3", owner=aphrodite)
-        await Toy.objects.create(name="Toy 6", owner=hermes)
+            await Toy.objects.create(name="Toy 4", owner=zeus)
+            await Toy.objects.create(name="Toy 5", owner=hermes)
+            await Toy.objects.create(name="Toy 2", owner=aphrodite)
+            await Toy.objects.create(name="Toy 1", owner=zeus)
+            await Toy.objects.create(name="Toy 3", owner=aphrodite)
+            await Toy.objects.create(name="Toy 6", owner=hermes)
 
-        toys = await Toy.objects.select_related("owner").order_by("name").all()
-        assert [x.name.replace("Toy ", "") for x in toys] == [
-            str(x + 1) for x in range(6)
-        ]
-        assert toys[0].owner == zeus
-        assert toys[1].owner == aphrodite
+            toys = await Toy.objects.select_related("owner").order_by("name").all()
+            assert [x.name.replace("Toy ", "") for x in toys] == [
+                str(x + 1) for x in range(6)
+            ]
+            assert toys[0].owner == zeus
+            assert toys[1].owner == aphrodite
 
-        toys = await Toy.objects.select_related("owner").order_by("owner__name").all()
-        assert toys[0].owner.name == toys[1].owner.name == "Aphrodite"
-        assert toys[2].owner.name == toys[3].owner.name == "Hermes"
-        assert toys[4].owner.name == toys[5].owner.name == "Zeus"
+            toys = (
+                await Toy.objects.select_related("owner").order_by("owner__name").all()
+            )
+            assert toys[0].owner.name == toys[1].owner.name == "Aphrodite"
+            assert toys[2].owner.name == toys[3].owner.name == "Hermes"
+            assert toys[4].owner.name == toys[5].owner.name == "Zeus"
 
-        owner = (
-            await Owner.objects.select_related("toys")
-            .order_by("toys__name")
-            .filter(name="Zeus")
-            .get()
-        )
-        assert owner.toys[0].name == "Toy 1"
-        assert owner.toys[1].name == "Toy 4"
+            owner = (
+                await Owner.objects.select_related("toys")
+                .order_by("toys__name")
+                .filter(name="Zeus")
+                .get()
+            )
+            assert owner.toys[0].name == "Toy 1"
+            assert owner.toys[1].name == "Toy 4"
 
-        owner = (
-            await Owner.objects.select_related("toys")
-            .order_by("-toys__name")
-            .filter(name="Zeus")
-            .get()
-        )
-        assert owner.toys[0].name == "Toy 4"
-        assert owner.toys[1].name == "Toy 1"
+            owner = (
+                await Owner.objects.select_related("toys")
+                .order_by("-toys__name")
+                .filter(name="Zeus")
+                .get()
+            )
+            assert owner.toys[0].name == "Toy 4"
+            assert owner.toys[1].name == "Toy 1"
 
-        owners = (
-            await Owner.objects.select_related("toys")
-            .order_by("-toys__name")
-            .filter(name__in=["Zeus", "Hermes"])
-            .all()
-        )
-        assert owners[0].toys[0].name == "Toy 6"
-        assert owners[0].toys[1].name == "Toy 5"
-        assert owners[0].name == "Hermes"
+            owners = (
+                await Owner.objects.select_related("toys")
+                .order_by("-toys__name")
+                .filter(name__in=["Zeus", "Hermes"])
+                .all()
+            )
+            assert owners[0].toys[0].name == "Toy 6"
+            assert owners[0].toys[1].name == "Toy 5"
+            assert owners[0].name == "Hermes"
 
-        assert owners[1].toys[0].name == "Toy 4"
-        assert owners[1].toys[1].name == "Toy 1"
-        assert owners[1].name == "Zeus"
+            assert owners[1].toys[0].name == "Toy 4"
+            assert owners[1].toys[1].name == "Toy 1"
+            assert owners[1].name == "Zeus"
 
-        await Toy.objects.create(name="Toy 7", owner=zeus)
+            await Toy.objects.create(name="Toy 7", owner=zeus)
 
-        owners = (
-            await Owner.objects.select_related("toys")
-            .order_by("-toys__name")
-            .filter(name__in=["Zeus", "Hermes"])
-            .all()
-        )
-        assert owners[0].toys[0].name == "Toy 7"
-        assert owners[0].toys[1].name == "Toy 4"
-        assert owners[0].toys[2].name == "Toy 1"
-        assert owners[0].name == "Zeus"
+            owners = (
+                await Owner.objects.select_related("toys")
+                .order_by("-toys__name")
+                .filter(name__in=["Zeus", "Hermes"])
+                .all()
+            )
+            assert owners[0].toys[0].name == "Toy 7"
+            assert owners[0].toys[1].name == "Toy 4"
+            assert owners[0].toys[2].name == "Toy 1"
+            assert owners[0].name == "Zeus"
 
-        assert owners[1].toys[0].name == "Toy 6"
-        assert owners[1].toys[1].name == "Toy 5"
-        assert owners[1].name == "Hermes"
+            assert owners[1].toys[0].name == "Toy 6"
+            assert owners[1].toys[1].name == "Toy 5"
+            assert owners[1].name == "Hermes"
 
-        toys = (
-            await Toy.objects.select_related("owner")
-            .order_by(["owner__name", "name"])
-            .limit(2)
-            .all()
-        )
-        assert len(toys) == 2
-        assert toys[0].name == "Toy 2"
-        assert toys[1].name == "Toy 3"
+            toys = (
+                await Toy.objects.select_related("owner")
+                .order_by(["owner__name", "name"])
+                .limit(2)
+                .all()
+            )
+            assert len(toys) == 2
+            assert toys[0].name == "Toy 2"
+            assert toys[1].name == "Toy 3"
+
+            athena = await Owner.objects.create(name="Athena", age=35)
+            apollo = await Owner.objects.create(name="Apollo", age=28)
+
+            await Toy.objects.create(name="Toy 8", owner=athena)
+            await Toy.objects.create(name="Toy 9", owner=apollo)
+
+            toys = (
+                await Toy.objects.select_related("owner")
+                .order_by(Toy.owner.age.asc(nulls_ordering=ormar.NullsOrdering.LAST))
+                .all()
+            )
+            assert toys[0].name == "Toy 9"
+            assert toys[1].name == "Toy 8"
+            assert all(t.owner.age is None for t in toys[2:])
+
+            toys = (
+                await Toy.objects.select_related("owner")
+                .order_by(Toy.owner.age.asc(nulls_ordering=ormar.NullsOrdering.FIRST))
+                .all()
+            )
+            assert all(t.owner.age is None for t in toys[:-2])
+            assert toys[-2].name == "Toy 9"
+            assert toys[-1].name == "Toy 8"
+
+            toys = (
+                await Toy.objects.select_related("owner")
+                .order_by(Toy.owner.age.desc(nulls_ordering=ormar.NullsOrdering.LAST))
+                .all()
+            )
+            assert toys[0].name == "Toy 8"
+            assert toys[1].name == "Toy 9"
+            assert all(t.owner.age is None for t in toys[2:])
+
+            toys = (
+                await Toy.objects.select_related("owner")
+                .order_by(Toy.owner.age.desc(nulls_ordering=ormar.NullsOrdering.FIRST))
+                .all()
+            )
+            assert all(t.owner.age is None for t in toys[:-2])
+            assert toys[-2].name == "Toy 8"
+            assert toys[-1].name == "Toy 9"
 
 
 @pytest.mark.asyncio
 async def test_sort_order_on_many_to_many():
     async with base_ormar_config.database:
-        factory1 = await Factory.objects.create(name="Factory 1")
-        factory2 = await Factory.objects.create(name="Factory 2")
+        async with base_ormar_config.database.transaction(force_rollback=True):
+            factory1 = await Factory.objects.create(name="Factory 1")
+            factory2 = await Factory.objects.create(name="Factory 2")
 
-        car1 = await Car.objects.create(name="Buggy", factory=factory1)
-        car2 = await Car.objects.create(name="Volkswagen", factory=factory2)
-        car3 = await Car.objects.create(name="Ferrari", factory=factory1)
-        car4 = await Car.objects.create(name="Volvo", factory=factory2)
-        car5 = await Car.objects.create(name="Skoda", factory=factory1)
-        car6 = await Car.objects.create(name="Seat", factory=factory2)
+            car1 = await Car.objects.create(name="Buggy", factory=factory1)
+            car2 = await Car.objects.create(name="Volkswagen", factory=factory2)
+            car3 = await Car.objects.create(name="Ferrari", factory=factory1)
+            car4 = await Car.objects.create(name="Volvo", factory=factory2)
+            car5 = await Car.objects.create(name="Skoda", factory=factory1)
+            car6 = await Car.objects.create(name="Seat", factory=factory2)
 
-        user1 = await User.objects.create(name="Mark")
-        user2 = await User.objects.create(name="Julie")
+            user1 = await User.objects.create(name="Mark")
+            user2 = await User.objects.create(name="Julie")
 
-        await user1.cars.add(car1)
-        await user1.cars.add(car3)
-        await user1.cars.add(car4)
-        await user1.cars.add(car5)
+            await user1.cars.add(car1)
+            await user1.cars.add(car3)
+            await user1.cars.add(car4)
+            await user1.cars.add(car5)
 
-        await user2.cars.add(car1)
-        await user2.cars.add(car2)
-        await user2.cars.add(car5)
-        await user2.cars.add(car6)
+            await user2.cars.add(car1)
+            await user2.cars.add(car2)
+            await user2.cars.add(car5)
+            await user2.cars.add(car6)
 
-        user = (
-            await User.objects.select_related("cars")
-            .filter(name="Mark")
-            .order_by("cars__name")
-            .get()
-        )
-        assert user.cars[0].name == "Buggy"
-        assert user.cars[1].name == "Ferrari"
-        assert user.cars[2].name == "Skoda"
-        assert user.cars[3].name == "Volvo"
+            user = (
+                await User.objects.select_related("cars")
+                .filter(name="Mark")
+                .order_by("cars__name")
+                .get()
+            )
+            assert user.cars[0].name == "Buggy"
+            assert user.cars[1].name == "Ferrari"
+            assert user.cars[2].name == "Skoda"
+            assert user.cars[3].name == "Volvo"
 
-        user = (
-            await User.objects.select_related("cars")
-            .filter(name="Mark")
-            .order_by("-cars__name")
-            .get()
-        )
-        assert user.cars[3].name == "Buggy"
-        assert user.cars[2].name == "Ferrari"
-        assert user.cars[1].name == "Skoda"
-        assert user.cars[0].name == "Volvo"
+            user = (
+                await User.objects.select_related("cars")
+                .filter(name="Mark")
+                .order_by("-cars__name")
+                .get()
+            )
+            assert user.cars[3].name == "Buggy"
+            assert user.cars[2].name == "Ferrari"
+            assert user.cars[1].name == "Skoda"
+            assert user.cars[0].name == "Volvo"
 
-        users = await User.objects.select_related("cars").order_by("-cars__name").all()
-        assert users[0].name == "Mark"
-        assert users[1].cars[0].name == "Volkswagen"
-        assert users[1].cars[1].name == "Skoda"
-        assert users[1].cars[2].name == "Seat"
-        assert users[1].cars[3].name == "Buggy"
+            users = (
+                await User.objects.select_related("cars").order_by("-cars__name").all()
+            )
+            assert users[0].name == "Mark"
+            assert users[1].cars[0].name == "Volkswagen"
+            assert users[1].cars[1].name == "Skoda"
+            assert users[1].cars[2].name == "Seat"
+            assert users[1].cars[3].name == "Buggy"
 
-        users = (
-            await User.objects.select_related(["cars__factory"])
-            .order_by(["-cars__factory__name", "cars__name"])
-            .all()
-        )
+            users = (
+                await User.objects.select_related(["cars__factory"])
+                .order_by(["-cars__factory__name", "cars__name"])
+                .all()
+            )
 
-        assert users[0].name == "Julie"
-        assert users[0].cars[0].name == "Seat"
-        assert users[0].cars[1].name == "Volkswagen"
-        assert users[0].cars[2].name == "Buggy"
-        assert users[0].cars[3].name == "Skoda"
+            assert users[0].name == "Julie"
+            assert users[0].cars[0].name == "Seat"
+            assert users[0].cars[1].name == "Volkswagen"
+            assert users[0].cars[2].name == "Buggy"
+            assert users[0].cars[3].name == "Skoda"
 
-        assert users[1].name == "Mark"
-        assert users[1].cars[0].name == "Volvo"
-        assert users[1].cars[1].name == "Buggy"
-        assert users[1].cars[2].name == "Ferrari"
-        assert users[1].cars[3].name == "Skoda"
+            assert users[1].name == "Mark"
+            assert users[1].cars[0].name == "Volvo"
+            assert users[1].cars[1].name == "Buggy"
+            assert users[1].cars[2].name == "Ferrari"
+            assert users[1].cars[3].name == "Skoda"
 
 
 @pytest.mark.asyncio
 async def test_sort_order_with_aliases():
     async with base_ormar_config.database:
-        al1 = await AliasTest.objects.create(name="Test4")
-        al2 = await AliasTest.objects.create(name="Test2")
-        al3 = await AliasTest.objects.create(name="Test1")
-        al4 = await AliasTest.objects.create(name="Test3")
+        async with base_ormar_config.database.transaction(force_rollback=True):
+            al1 = await AliasTest.objects.create(name="Test4")
+            al2 = await AliasTest.objects.create(name="Test2")
+            al3 = await AliasTest.objects.create(name="Test1")
+            al4 = await AliasTest.objects.create(name="Test3")
 
-        aliases = await AliasTest.objects.order_by("-name").all()
-        assert [alias.name[-1] for alias in aliases] == ["4", "3", "2", "1"]
+            aliases = await AliasTest.objects.order_by("-name").all()
+            assert [alias.name[-1] for alias in aliases] == ["4", "3", "2", "1"]
 
-        nest1 = await AliasNested.objects.create(name="Try1")
-        nest2 = await AliasNested.objects.create(name="Try2")
-        nest3 = await AliasNested.objects.create(name="Try3")
-        nest4 = await AliasNested.objects.create(name="Try4")
+            nest1 = await AliasNested.objects.create(name="Try1")
+            nest2 = await AliasNested.objects.create(name="Try2")
+            nest3 = await AliasNested.objects.create(name="Try3")
+            nest4 = await AliasNested.objects.create(name="Try4")
 
-        al1.nested = nest1
-        await al1.update()
+            al1.nested = nest1
+            await al1.update()
 
-        al2.nested = nest2
-        await al2.update()
+            al2.nested = nest2
+            await al2.update()
 
-        al3.nested = nest3
-        await al3.update()
+            al3.nested = nest3
+            await al3.update()
 
-        al4.nested = nest4
-        await al4.update()
+            al4.nested = nest4
+            await al4.update()
 
-        aliases = (
-            await AliasTest.objects.select_related("nested")
-            .order_by("-nested__name")
-            .all()
-        )
-        assert aliases[0].nested.name == "Try4"
-        assert aliases[1].nested.name == "Try3"
-        assert aliases[2].nested.name == "Try2"
-        assert aliases[3].nested.name == "Try1"
+            aliases = (
+                await AliasTest.objects.select_related("nested")
+                .order_by("-nested__name")
+                .all()
+            )
+            assert aliases[0].nested.name == "Try4"
+            assert aliases[1].nested.name == "Try3"
+            assert aliases[2].nested.name == "Try2"
+            assert aliases[3].nested.name == "Try1"


### PR DESCRIPTION
## Summary
Ports [#769](https://github.com/ormar-orm/ormar/pull/769) to the current codebase and incorporates the review feedback that was never addressed upstream. Adds `Model.field.asc(nulls_ordering=...)` / `.desc(nulls_ordering=...)` backed by a new `ormar.NullsOrdering` enum (`FIRST` / `LAST`).

- `NullsOrdering(str, Enum)` in `ormar/queryset/clause.py`, re-exported from `ormar.queryset` and top-level `ormar`.
- `OrderAction` gets an optional `nulls_ordering`; a new `_build_order_expression()` helper assembles the final SQL.
- Emits standard `NULLS FIRST` / `NULLS LAST` on PostgreSQL and SQLite (3.30+). On MySQL, emulates via `col IS [NOT] NULL, col <dir>` — a pure sort-key prefix, no effect on the result set.
- Fixes the nested-prefix bug the reviewer flagged on the original PR: the fully-qualified `"table"."col"` is threaded through **both** halves of the MySQL expression, so joined/aliased tables keep their prefix.
- `FieldAccessor.asc()` / `.desc()` accept `Optional[NullsOrdering]` and raise `ValueError` for other types.
- `QuerySet.order_by()` / `QuerysetProxy.order_by()` needed no signature change — they already accept `OrderAction` instances, so `Model.field.asc(nulls_ordering=...)` propagates through both.
- Docs: new subsection in `docs/queries/filter-and-sort.md` with usage and the MySQL dialect note.

## Test plan
- [x] `pytest tests/test_queries/test_order_by.py` — 5 tests pass on SQLite
- [x] `make pre-commit` — ruff format, ruff check, mypy strict all clean
- [x] `make coverage` — 503 passed, 1 skipped, 100% total coverage
- [ ] CI `make test_mysql` — exercises the MySQL emulation branch (marked `# pragma: no cover` in the default SQLite run)
- [ ] CI `make test_pg` — exercises the native `NULLS FIRST/LAST` path on PostgreSQL

New tests added:
- `test_sort_order_nulls_first_last` — dedicated main-model test with unique `sort_order` values covering all four `{asc, desc} × {FIRST, LAST}` combinations plus two `ValueError` guards.
- `test_sort_order_on_related_model` — extended with the same four combinations using `Toy.owner.age`, exercising the joined-table prefix path that the original PR's MySQL branch broke.
- Every test in `test_order_by.py` is now wrapped in `database.transaction(force_rollback=True)` so writes roll back between tests.