### PR TITLE
fix(benchmarks): unblock codspeed runs on pytest 9

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,7 +1,6 @@
 import asyncio
 import random
 import string
-import time
 
 import nest_asyncio
 import pytest
@@ -88,9 +87,6 @@ async def authors_in_db(num_models: int):
 
 
 @pytest_asyncio.fixture
-@pytest.mark.benchmark(
-    min_rounds=1, timer=time.process_time, disable_gc=True, warmup=False
-)
 async def aio_benchmark(benchmark):
     def _fixture_wrapper(func):
         def _func_wrapper(*args, **kwargs):

--- a/benchmarks/test_benchmark_bulk_update.py
+++ b/benchmarks/test_benchmark_bulk_update.py
@@ -19,7 +19,7 @@ async def test_updating_models_in_bulk(
         await Author.objects.bulk_update(authors)
 
     for author in authors_in_db:
-        author.name = "".join(random.sample(string.ascii_letters, 5))
+        author.name = "u_" + "".join(random.sample(string.ascii_letters, 5))
 
     update(authors_in_db)
     author = await Author.objects.get(id=authors_in_db[0].id)

--- a/benchmarks/test_benchmark_update.py
+++ b/benchmarks/test_benchmark_update.py
@@ -18,7 +18,7 @@ async def test_updating_models_individually(
     async def update(authors: list[Author]):
         for author in authors:
             _ = await author.update(
-                name="".join(random.sample(string.ascii_letters, 5))
+                name="u_" + "".join(random.sample(string.ascii_letters, 5))
             )
 
     update(authors_in_db)


### PR DESCRIPTION
## Summary

- Drop the no-op `@pytest.mark.benchmark(...)` decorator on the `aio_benchmark` fixture in `benchmarks/conftest.py`. Marks on fixtures never had any effect and pytest 9 promoted the deprecation to a hard `PytestRemovedIn9Warning` raised at conftest import time, so every benchmark run since the `pytest 8.4.2 → 9.0.3` bump (#1609) hung and got auto-cancelled at the 24h job timeout.
- Prefix the rewritten name with `"u_"` in `test_benchmark_update.py` and `test_benchmark_bulk_update.py`. The assertion `author.name != starting_first_name` previously compared two random 5-char strings drawn from `string.ascii_letters` — over thousands of codspeed walltime iterations the ~1/311M per-call collision eventually surfaced (CI showed `'DpwEX' != 'DpwEX'`). The prefix makes the new value structurally unable to match.

Without this, master has had no successful benchmark baseline since `53d2462` (2026-03-31), which is why the recent `feature/flatten-fields` PR (#1641) shows a phantom -35% regression and a "Different runtime environments detected" warning — codspeed is comparing against a 5-week-old run on different macro-runner hardware.

## Test plan

- [x] `pytest benchmarks/test_benchmark_update.py benchmarks/test_benchmark_bulk_update.py --codspeed` passes locally on pytest 9.0.3 + pytest-codspeed 4.5.0
- [ ] codspeed-benchmarks CI succeeds on this PR, producing a fresh master baseline once merged