### PR TITLE
perf: cache & specialize _process_kwargs hot path

### DIFF
--- a/ormar/models/metaclass.py
+++ b/ormar/models/metaclass.py
@@ -76,6 +76,12 @@ def add_cached_properties(new_model: type["Model"]) -> None:
     new_model._json_fields = set()
     new_model._bytes_fields = set()
     new_model._onupdate_fields = set()
+    # Lazy-populated in NewBaseModel._process_kwargs on first init per class.
+    # ormar_config.extra and ormar_config.model_fields are not finalized at
+    # this point in class creation, so eager init would be premature.
+    new_model._pydantic_field_names = None
+    new_model._extra_is_ignore = None
+    new_model._allowed_kwarg_names = None
 
 
 def add_property_fields(new_model: type["Model"], attrs: dict) -> None:  # noqa: CCR001

--- a/ormar/models/newbasemodel.py
+++ b/ormar/models/newbasemodel.py
@@ -114,6 +114,9 @@ class NewBaseModel(pydantic.BaseModel, ModelTableProxy, metaclass=ModelMetaclass
         _json_fields: set
         _bytes_fields: set
         _onupdate_fields: set
+        _pydantic_field_names: Optional[frozenset[str]]
+        _extra_is_ignore: Optional[bool]
+        _allowed_kwarg_names: Optional[frozenset[str]]
         ormar_config: OrmarConfig
 
     # noinspection PyMissingConstructor
@@ -374,71 +377,65 @@ class NewBaseModel(pydantic.BaseModel, ModelTableProxy, metaclass=ModelMetaclass
         :return: modified kwargs
         :rtype: tuple[dict, dict]
         """
-        property_fields = self.ormar_config.property_fields
-        model_fields = self.ormar_config.model_fields
-        pydantic_fields = set(self.__class__.model_fields.keys())
+        cls = type(self)
+        config = cls.ormar_config
+        model_fields = config.model_fields
+
+        pydantic_fields = cls._pydantic_field_names
+        if pydantic_fields is None:
+            pydantic_fields = frozenset(cls.model_fields.keys())
+            cls._pydantic_field_names = pydantic_fields
 
         # remove property fields
-        for prop_filed in property_fields:
-            kwargs.pop(prop_filed, None)
+        for prop_field in config.property_fields:
+            kwargs.pop(prop_field, None)
 
         if "pk" in kwargs:
-            kwargs[self.ormar_config.pkname] = kwargs.pop("pk")
+            kwargs[config.pkname] = kwargs.pop("pk")
 
         # extract through fields
-        through_tmp_dict = dict()
-        for field_name in self.extract_through_names():
-            through_tmp_dict[field_name] = kwargs.pop(field_name, None)
+        through_tmp_dict = {
+            field_name: kwargs.pop(field_name, None)
+            for field_name in self.extract_through_names()
+        }
 
-        kwargs = self._remove_extra_parameters_if_they_should_be_ignored(
-            kwargs=kwargs, model_fields=model_fields, pydantic_fields=pydantic_fields
-        )
+        extra_is_ignore = cls._extra_is_ignore
+        if extra_is_ignore is None:
+            extra_is_ignore = config.extra == Extra.ignore
+            cls._extra_is_ignore = extra_is_ignore
+
+        if extra_is_ignore:
+            allowed = cls._allowed_kwarg_names
+            if allowed is None:
+                allowed = frozenset(model_fields.keys()) | pydantic_fields
+                cls._allowed_kwarg_names = allowed
+            kwargs = {k: v for k, v in kwargs.items() if k in allowed}
+
+        json_fields = cls._json_fields
+        bytes_fields = cls._bytes_fields
+
         try:
-            new_kwargs: dict[str, Any] = {
-                k: self._convert_to_bytes(
-                    k,
-                    self._convert_json(
-                        k,
-                        (
-                            model_fields[k].expand_relationship(
-                                v, self, to_register=False
-                            )
-                            if k in model_fields
-                            else (v if k in pydantic_fields else model_fields[k])
-                        ),
-                    ),
-                )
-                for k, v in kwargs.items()
-            }
+            new_kwargs: dict[str, Any] = {}
+            for k, v in kwargs.items():
+                if k in model_fields:
+                    v = model_fields[k].expand_relationship(v, self, to_register=False)
+                elif k not in pydantic_fields:
+                    # raises KeyError, handled below to produce a friendly ModelError
+                    model_fields[k]
+                if k in json_fields:
+                    v = encode_json(v)
+                if k in bytes_fields and v is not None:
+                    v = decode_bytes(
+                        value=v,
+                        represent_as_string=model_fields[k].represent_as_base64_str,
+                    )
+                new_kwargs[k] = v
         except KeyError as e:
             raise ModelError(
                 f"Unknown field '{e.args[0]}' for model {self.get_name(lower=False)}"
             )
 
         return new_kwargs, through_tmp_dict
-
-    def _remove_extra_parameters_if_they_should_be_ignored(
-        self, kwargs: dict, model_fields: dict, pydantic_fields: set
-    ) -> dict:
-        """
-        Removes the extra fields from kwargs if they should be ignored.
-
-        :param kwargs: passed arguments
-        :type kwargs: dict
-        :param model_fields: dictionary of model fields
-        :type model_fields: dict
-        :param pydantic_fields: set of pydantic fields names
-        :type pydantic_fields: set
-        :return: dict without extra fields
-        :rtype: dict
-        """
-        if self.ormar_config.extra == Extra.ignore:
-            kwargs = {
-                k: v
-                for k, v in kwargs.items()
-                if k in model_fields or k in pydantic_fields
-            }
-        return kwargs
 
     def _initialize_internal_attributes(self) -> None:
         """
@@ -1229,28 +1226,6 @@ class NewBaseModel(pydantic.BaseModel, ModelTableProxy, metaclass=ModelMetaclass
             setattr(self, key, value)
         return self
 
-    def _convert_to_bytes(
-        self, column_name: str, value: Any
-    ) -> Union[str, builtins.dict]:
-        """
-        Converts value to bytes from string
-
-        :param column_name: name of the field
-        :type column_name: str
-        :param value: value fo the field
-        :type value: Any
-        :return: converted value if needed, else original value
-        :rtype: Any
-        """
-        if column_name not in self._bytes_fields:
-            return value
-        field = self.ormar_config.model_fields[column_name]
-        if value is not None:
-            value = decode_bytes(
-                value=value, represent_as_string=field.represent_as_base64_str
-            )
-        return value
-
     def _convert_bytes_to_str(
         self, column_name: str, value: Any
     ) -> Union[str, builtins.dict]:
@@ -1274,23 +1249,6 @@ class NewBaseModel(pydantic.BaseModel, ModelTableProxy, metaclass=ModelMetaclass
         ):
             return base64.b64encode(value).decode()
         return value
-
-    def _convert_json(
-        self, column_name: str, value: Any
-    ) -> Union[str, builtins.dict, None]:
-        """
-        Converts value to/from json if needed (for Json columns).
-
-        :param column_name: name of the field
-        :type column_name: str
-        :param value: value fo the field
-        :type value: Any
-        :return: converted value if needed, else original value
-        :rtype: Any
-        """
-        if column_name not in self._json_fields:
-            return value
-        return encode_json(value)
 
     def _extract_own_model_fields(self) -> builtins.dict:
         """

--- a/ormar/models/quick_access_views.py
+++ b/ormar/models/quick_access_views.py
@@ -22,7 +22,6 @@ quick_access_set = {
     "__private_attributes__",
     "__same__",
     "_calculate_keys",
-    "_convert_json",
     "_extract_db_related_names",
     "_extract_model_db_fields",
     "_extract_nested_models",


### PR DESCRIPTION
## Summary

Profile-driven refactor of `NewBaseModel._process_kwargs`, which fires on every `Model.__init__` — both user construction and per-row hydration. Removes redundant per-init work and skips no-op conversion calls for fields that are neither JSON nor bytes.

This is the first of several Tier 1 perf commits planned on this branch family.

## Changes

- Cache `_pydantic_field_names`, `_extra_is_ignore`, `_allowed_kwarg_names` on the class (lazy-populated on first init); installed via metaclass `add_cached_properties` alongside the existing `_json_fields`/`_bytes_fields` caches.
- Replace the nested `_convert_to_bytes(_convert_json(...))` dict-comp with an explicit dispatch loop. The common path (regular ormar field, no JSON, no bytes) avoids the function-call overhead entirely.
- Inline `_remove_extra_parameters_if_they_should_be_ignored` behind the cached `_extra_is_ignore` bool; remove the method (no external callers).
- Remove now-unused `_convert_to_bytes` / `_convert_json` methods and the orphaned `_convert_json` entry in `quick_access_views`.

Behavior unchanged: same `ModelError` messaging on unknown fields, same JSON encoding via `encode_json`, same base64 bytes handling via `decode_bytes`.

## Benchmark deltas (median, pytest-benchmark)

| Test | Before µs | After µs | Δ |
|---|---|---|---|
| `test_initializing_models[250]` | 4 852 | 3 161 | **−34.9 %** |
| `test_initializing_models[500]` | 7 169 | 6 535 | **−8.8 %** |
| `test_iterate[500]` | 14 424 | 13 288 | **−7.9 %** |
| `test_iterate[1000]` | 26 742 | 24 775 | **−7.4 %** |
| `test_get_all_with_related_models[40]` | 7 030 | 6 802 | −3.2 % |
| `test_initializing_models_with_related_models[10]` | 344 | 337 | −2.1 % |
| I/O-bound `get_one` / `first` / `get_or_none` | — | — | within noise |

cProfile (`all_with_related` scenario): `_process_kwargs` tottime **0.365 s → 0.238 s (−35 %)**. The line-397 dict-comp is no longer a separate hotspot.

## Test plan

- [x] `make pre-commit` (ruff format, ruff check, mypy strict) — clean
- [x] `make coverage` — 628 passed, 25 skipped, **100.00 %** coverage
- [x] Targeted: `test_extra_ignore_parameter`, `test_json_fields`, `test_encryption`, `test_kwargs_injection` — green; unknown-field `ModelError` message byte-for-byte unchanged
- [x] cProfile re-run on `init_plain` and `all_with_related` — confirms hotspot reduction; `_convert_json`/`_convert_to_bytes` no longer in the trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)