### PR TITLE
perf: replace RelationProxy.__getattribute__ with explicit count/clear

### DIFF
--- a/ormar/relations/relation_proxy.py
+++ b/ormar/relations/relation_proxy.py
@@ -15,9 +15,6 @@ else:
     T = TypeVar("T", bound="Model")
 
 
-_QUERYSET_PROXY_METHODS = frozenset({"count", "clear"})
-
-
 class RelationProxy(Generic[T], list[T]):
     """
     Proxy of the Relation that is a list with special methods.
@@ -169,20 +166,38 @@ class RelationProxy(Generic[T], list[T]):
         except ReferenceError:
             return False
 
-    def __getattribute__(self, item: str) -> Any:
+    async def count(self, distinct: bool = True) -> int:  # type: ignore[override]
         """
-        Since some QuerySetProxy methods overwrite builtin list methods we
-        catch calls to them and delegate it to QuerySetProxy instead.
+        Returns count of related models. Delegates to ``QuerysetProxy.count``.
 
-        :param item: name of attribute
-        :type item: str
-        :return: value of attribute
-        :rtype: Any
+        Defined explicitly to shadow ``list.count`` so attribute lookup resolves
+        to the relation-aware version without going through ``__getattribute__``
+        on every attribute access.
+
+        :param distinct: flag if the primary table rows should be distinct
+        :type distinct: bool
+        :return: number of related models
+        :rtype: int
         """
-        if item in _QUERYSET_PROXY_METHODS:
-            self._initialize_queryset()
-            return getattr(self.queryset_proxy, item)
-        return super().__getattribute__(item)
+        self._initialize_queryset()
+        return await self.queryset_proxy.count(distinct=distinct)
+
+    async def clear(self, keep_reversed: bool = True) -> int:  # type: ignore[override]
+        """
+        Removes all related models from the relation. Delegates to
+        ``QuerysetProxy.clear``.
+
+        Defined explicitly to shadow ``list.clear`` so attribute lookup resolves
+        to the relation-aware version without going through ``__getattribute__``
+        on every attribute access.
+
+        :param keep_reversed: keep reversed FK rows in the database
+        :type keep_reversed: bool
+        :return: number of removed relation entries
+        :rtype: int
+        """
+        self._initialize_queryset()
+        return await self.queryset_proxy.clear(keep_reversed=keep_reversed)
 
     def __getattr__(self, item: str) -> Any:
         """


### PR DESCRIPTION
## Summary

Profile-driven removal of the per-attribute-access Python override on `RelationProxy`. The previous `__getattribute__` existed solely to redirect two list-method names (`count`, `clear`) to the `QuerysetProxy` versions; every other attribute access paid the cost of a Python-level `__getattribute__` call only to fall through to `super()`.

cProfile (`all_with_related`, 40 000 row hydrations): `__getattribute__` was 0.354 s tottime / 6.2 % of scenario time, with 420 000 calls. After this change it is no longer in the top 25 by tottime — attribute access goes through the C-level lookup path.

## Changes

- Define `count()` and `clear()` as explicit `async` methods directly on `RelationProxy`. They shadow `list.count` / `list.clear` by virtue of MRO and delegate to `queryset_proxy` after `self._initialize_queryset()`.
- Delete the `__getattribute__` override and the `_QUERYSET_PROXY_METHODS` frozenset.

The observable async semantics are unchanged: callers always did `await proxy.count(...)` / `await proxy.clear(...)`. The previous override returned a bound async method from `QuerysetProxy`; the new methods are themselves `async` — both produce the same coroutine. Same signatures (`distinct=True` / `keep_reversed=True` defaults), same delegation path, same `QuerysetProxy` initialization trigger.

## Benchmark deltas (median, pytest-benchmark, --warmup=on, 10+ rounds)

| Test | Before | After | Δ |
|---|---|---|---|
| `test_get_all_with_related_models[10]` | 2 449 µs | 2 027 µs | **−17.2 %** |
| `test_get_all_with_related_models[20]` | 3 999 µs | 3 373 µs | **−15.6 %** |
| `test_get_all_with_related_models[40]` | 7 106 µs | 6 561 µs | **−7.7 %** |
| `test_get_all[250]` | 5 764 µs | 5 010 µs | **−13.1 %** |
| `test_get_all[500]` | 10 345 µs | 9 317 µs | **−9.9 %** |
| `test_get_all[1000]` | 19 187 µs | 17 972 µs | **−6.4 %** |
| `test_iterate[*]` | — | — | within noise |
| single-row `get_one` / `first` | — | — | I/O-dominated, ±15 % noise |

## Test plan

- [x] `make pre-commit` — clean (one `# type: ignore[override]` for `count` since signature differs from `Sequence.count`)
- [x] `make coverage` — 628 passed, 25 skipped, **100.00 %** coverage
- [x] `tests/test_relations/`, `tests/test_queries/test_queryproxy_on_m2m_models.py`, `test_aggr_functions.py`, `test_reverse_fk_queryset.py` all green
- [x] cProfile on `all_with_related` confirms `__getattribute__` no longer in top-25 by tottime

🤖 Generated with [Claude Code](https://claude.com/claude-code)