### PR TITLE
perf: precompute field.relation_type and slim RelationsManager init

### DIFF
--- a/ormar/fields/base.py
+++ b/ormar/fields/base.py
@@ -13,6 +13,20 @@ from ormar.fields.sqlalchemy_encrypted import (
 
 if TYPE_CHECKING:  # pragma no cover
     from ormar.models import Model, NewBaseModel
+    from ormar.relations.relation import RelationType
+
+# Lazy-imported on first BaseField construction to avoid a circular import
+# (ormar.relations → relation_manager → utils → foreign_key → base).
+_RELATION_TYPE: Optional[type["RelationType"]] = None
+
+
+def _relation_type_cls() -> type["RelationType"]:
+    global _RELATION_TYPE
+    if _RELATION_TYPE is None:
+        from ormar.relations.relation import RelationType as _RT
+
+        _RELATION_TYPE = _RT
+    return _RELATION_TYPE
 
 
 class BaseField(FieldInfo):  # type: ignore[misc]
@@ -52,6 +66,18 @@ class BaseField(FieldInfo):  # type: ignore[misc]
             "is_relation", None
         )  # ForeignKeyField + subclasses
         self.is_through: bool = kwargs.pop("is_through", False)  # ThroughFields
+        rt = _relation_type_cls()
+        self.relation_type: Optional["RelationType"]
+        if self.is_multi:
+            self.relation_type = rt.MULTIPLE
+        elif self.is_through:
+            self.relation_type = rt.THROUGH
+        elif self.virtual:
+            self.relation_type = rt.REVERSE
+        elif self.is_relation:
+            self.relation_type = rt.PRIMARY
+        else:
+            self.relation_type = None
 
         self.through_relation_name = kwargs.pop("through_relation_name", None)
         self.through_reverse_relation_name = kwargs.pop(

--- a/ormar/relations/relation.py
+++ b/ormar/relations/relation.py
@@ -60,7 +60,7 @@ class Relation(Generic[T]):
         self.manager = manager
         self._owner: "Model" = manager.owner
         self._type: RelationType = type_
-        self._to_remove: set = set()
+        self._to_remove: set[int] = set()
         self.to: type["T"] = to
         self._through = through
         self.field_name: str = field_name

--- a/ormar/relations/relation_manager.py
+++ b/ormar/relations/relation_manager.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Optional, Sequence, Union
 from weakref import proxy
 
-from ormar.relations.relation import Relation, RelationType
+from ormar.relations.relation import Relation
 from ormar.relations.utils import get_relations_sides_and_names
 
 if TYPE_CHECKING:  # pragma no cover
@@ -20,10 +20,8 @@ class RelationsManager:
         owner: Optional["Model"] = None,
     ) -> None:
         self.owner = proxy(owner)
-        self._related_fields = related_fields or []
-        self._related_names = [field.name for field in self._related_fields]
         self._relations: dict[str, Relation] = dict()
-        for field in self._related_fields:
+        for field in related_fields or []:
             self._add_relation(field)
 
     def __contains__(self, item: str) -> bool:
@@ -35,7 +33,7 @@ class RelationsManager:
         :return: result of the check
         :rtype: bool
         """
-        return item in self._related_names
+        return item in self._relations
 
     def clear(self) -> None:
         for relation in self._relations.values():
@@ -138,21 +136,6 @@ class RelationsManager:
             return relation
         return None
 
-    def _get_relation_type(self, field: "BaseField") -> RelationType:
-        """
-        Returns type of the relation declared on a field.
-
-        :param field: field with relation declaration
-        :type field: BaseField
-        :return: type of the relation defined on field
-        :rtype: RelationType
-        """
-        if field.is_multi:
-            return RelationType.MULTIPLE
-        if field.is_through:
-            return RelationType.THROUGH
-        return RelationType.PRIMARY if not field.virtual else RelationType.REVERSE
-
     def _add_relation(self, field: "BaseField") -> None:
         """
         Registers relation in the manager.
@@ -161,9 +144,13 @@ class RelationsManager:
         :param field: field with relation declaration
         :type field: BaseField
         """
+        # ``relation_type`` is set in ``BaseField.__init__`` for every
+        # relation/through field; ``_add_relation`` is only called for
+        # such fields, so the value is never None here.
+        assert field.relation_type is not None
         self._relations[field.name] = Relation(
             manager=self,
-            type_=self._get_relation_type(field),
+            type_=field.relation_type,
             field_name=field.name,
             to=field.to,
             through=getattr(field, "through", None),


### PR DESCRIPTION
## Summary

Three micro-optimizations on the per-`Model.__init__` relation-bookkeeping path. Stacked on top of #1650 (the `__getattribute__` cleanup).

1. **Precompute `field.relation_type` in `BaseField.__init__`**. The branch on `is_multi` / `is_through` / `virtual` / `is_relation` runs once at field-declaration time. `RelationsManager._add_relation` then reads `field.relation_type` directly instead of calling `_get_relation_type(field)` per relation per `Model.__init__`. Saves ~100 k method calls per `all_with_related` scenario; `_get_relation_type` deleted. `RelationType` is lazy-imported via a module-level `_relation_type_cls()` helper to break the circular `ormar.relations` → `relation_manager` → `utils` → `foreign_key` → `base` chain.
2. **Drop `RelationsManager._related_fields` / `_related_names`**. `__contains__` now checks the `_relations` dict (already keyed by field name). Removes a per-init list-comp + two `STORE_ATTR` ops.
3. **`_add_relation` reads `field.relation_type` directly**. An `assert` narrows the `Optional` for mypy and documents the invariant (only relation/through fields reach this path).

Behavior unchanged.

## Benchmark deltas (median, pytest-benchmark, --warmup, 10+ rounds)

| Test | Before | After | Δ |
|---|---|---|---|
| `test_initializing_models[250]` | 2 957 µs | 2 726 µs | **−7.8 %** |
| `test_get_all[1000]` | 17.29 ms | 16.06 ms | **−7.1 %** |
| `test_initializing_models_with_related_models[10]` | 308 µs | 291 µs | **−5.7 %** |
| `test_initializing_models[500]` | 5 462 µs | 5 371 µs | −1.7 % |
| Single-row `get_one` / `first` | — | — | I/O-dominated, within noise |

cProfile (`all_with_related` scenario): 5.481 s → 5.328 s = **−2.8 %**. `_get_relation_type` no longer in the trace.

## Test plan

- [x] `make pre-commit` — clean (mypy strict)
- [x] `make coverage` — 628 passed, 25 skipped, **100.00 %** coverage
- [x] cProfile on `all_with_related` confirms `_get_relation_type` no longer in top-25 by tottime
- [x] All targeted tests green: `tests/test_relations/`, `tests/test_queries/test_queryproxy_on_m2m_models.py`, `test_aggr_functions.py`, `test_reverse_fk_queryset.py`

## Notes

- This PR's base is #1650 (`perf/relationproxy-getattribute`) — once that merges into `check-optimisations-and-rs`, the diff here will rebase to just the three files shown.
- `_resolve_relation_type` was simplified during review from function-attribute caching to a module-level `_RELATION_TYPE` variable + `global` (idiomatic, no `# type: ignore` needed).
- An earlier `_to_remove` sentinel change (None instead of always-empty `set()`) was reverted during review — the saving (~7 µs / scenario) didn't justify the added Optional type + assert + conditional checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)