### PR TITLE
perf: unify Relation reverse/m2m container with __dict__ slot

### DIFF
--- a/ormar/relations/relation.py
+++ b/ormar/relations/relation.py
@@ -113,15 +113,15 @@ class Relation(Generic[T]):
             for i, x in enumerate(self.related_models)  # type: ignore
             if i not in self._to_remove
         ]
-        self.related_models = RelationProxy(
+        proxy = RelationProxy(
             relation=self,
             type_=self._type,
             to=self.to,
             field_name=self.field_name,
             data_=cleaned_data,
         )
-        relation_name = self.field_name
-        self._owner.__dict__[relation_name] = cleaned_data
+        self.related_models = proxy
+        self._owner.__dict__[self.field_name] = proxy
         self._to_remove = set()
 
     def _find_existing(
@@ -157,6 +157,12 @@ class Relation(Generic[T]):
         Adds child Model to relation, either sets child as related model or adds
         it to the list in RelationProxy depending on relation type.
 
+        For reverse / many-to-many relations the ``RelationProxy`` itself is
+        stored under ``_owner.__dict__[relation_name]``, so a single O(1)
+        membership check on the proxy's hash cache covers both the relation
+        bookkeeping and the pydantic-visible ``__dict__`` slot — no parallel
+        list, no second linear scan.
+
         :param child: model to add to relation
         :type child: Model
         """
@@ -164,24 +170,15 @@ class Relation(Generic[T]):
         if self._type in (RelationType.PRIMARY, RelationType.THROUGH):
             self.related_models = child
             self._owner.__dict__[relation_name] = child
-        else:
-            proxy = self._ensure_proxy()
-            if self._find_existing(child) is None:
-                proxy.append(child)
-                rel = self._owner.__dict__.get(relation_name, [])
-                rel = rel or []
-                if not isinstance(rel, list):
-                    rel = [rel]
-                self._populate_owner_side_dict(rel=rel, child=child)
-                self._owner.__dict__[relation_name] = rel
-
-    def _populate_owner_side_dict(self, rel: list["Model"], child: "Model") -> None:
-        try:
-            if child not in rel:
-                rel.append(child)
-        except ReferenceError:
-            rel.clear()
-            rel.append(child)
+            return
+        proxy = self._ensure_proxy()
+        # ``_find_existing`` is the membership check *plus* a dead-weakref
+        # probe — when a hash collision lands on a stale entry we need that
+        # probe to populate ``_to_remove`` so the next ``get()`` triggers
+        # ``_clean_related``.
+        if self._find_existing(child) is None:
+            proxy.append(child)
+            self._owner.__dict__[relation_name] = proxy
 
     def remove(self, child: Union["NewBaseModel", type["NewBaseModel"]]) -> None:
         """
@@ -200,7 +197,6 @@ class Relation(Generic[T]):
             position = self._find_existing(child)
             if position is not None:
                 self.related_models.pop(position)  # type: ignore
-                del self._owner.__dict__[relation_name][position]
 
     def get(self) -> Optional[Union[list["Model"], "Model"]]:
         """


### PR DESCRIPTION
## Summary

Reverse / m2m relations were tracked in two parallel containers — the `RelationProxy` on the `Relation`, and a plain list in the owner's `__dict__` slot read by pydantic for serialization / pickling. Every `Relation.add` did six steps for one logical "register child":

1. Hash-based membership check on the proxy (cheap)
2. Append to the proxy + cache update (cheap)
3. Dict load of the parallel list
4. Linear `child not in rel` scan (inside a `try` block that caught `ReferenceError` as a "nuke and restart" signal)
5. Append to the parallel list
6. Dict store

Steps 3–6 collapse once the proxy itself becomes the `__dict__` slot. `RelationProxy` is a `list[T]` subclass, so pydantic and `pickle` see the same shape they did before.

### What changed (`ormar/relations/relation.py` only)

- `Relation.add` REVERSE/MULTIPLE branch: dropped the parallel-list dance and the helper `_populate_owner_side_dict`. The proxy is stored directly under `__dict__[relation_name]`, so a single `_relation_cache` covers both relation bookkeeping and the pydantic-visible slot.
- Kept the `_find_existing` call (not just `child in proxy`) because its else branch probes for dead weakrefs as a side effect — when a hash collision lands on a stale entry, that probe populates `_to_remove` so the next `get()` runs `_clean_related`. Inlining the membership check would have lost that signal (covered by `tests/test_relations/test_weakref_checking.py`).
- `Relation.remove` REVERSE/MULTIPLE branch: dropped the now-redundant `del self._owner.__dict__[relation_name][position]` — `proxy.pop(position)` already updates the unified slot and maintains the cache.
- `Relation._clean_related`: stores the rebuilt `RelationProxy` in both `self.related_models` and `self._owner.__dict__[name]` (it stored a plain list there before, which is what made the two containers diverge after a clean).
- Deleted `_populate_owner_side_dict` (no callers post-unification).

## Benchmarks (sqlite, on-disk; warmup on, min_rounds=10–20)

vs the post-#1654 optimization tip:

| Workload | Before | After | Δ |
|---|---:|---:|---:|
| `init_with_related[40]` | 1983 µs | 918 µs | **−53.7%** |
| `init_with_related[20]` | 718 µs | 457 µs | **−36.4%** |
| `init_with_related[10]` | 303 µs | 239 µs | **−21.1%** |
| `get_all_with_related[40]` | 5079 µs | 4552 µs | **−10.4%** |
| `init / get_all / iterate` (no relations) | — | — | within noise |
| `get_one[1000]` (DB-bound) | — | — | within noise |

Workloads that don't register related models stay flat (the change is no-op for them). The audit projected 10–15% on related-model registration paths; the actual gain on the canonical `init_with_related` workload is over 3× that — the duplicate scan inside an implicit weakproxy-iteration `try/except` was costing more than call-count profiling suggested.

## Test plan

- [x] `make pre-commit` clean (ruff format, ruff check, mypy)
- [x] `make coverage` at 100%
- [x] `tests/test_relations/`, `tests/test_signals/`, `tests/test_inheritance_and_pydantic_generation/`, `tests/test_model_definition/`, `tests/test_queries/` — all green (389 passed)
- [x] `tests/test_relations/test_weakref_checking.py` (the dead-weakref cleanup case) verified — required keeping `_find_existing` rather than inlining
- [x] Manual `model_dump()` and `pickle.dumps`/`loads` round-trip on a model with reverse children — output matches pre-change shape
- [ ] CI run on PG / MySQL dialects