### PR TITLE
perf: fast-path expand_relationship for already-typed Model values

### DIFF
--- a/ormar/fields/foreign_key.py
+++ b/ormar/fields/foreign_key.py
@@ -2,6 +2,7 @@ import string
 import sys
 import uuid
 from dataclasses import dataclass
+from functools import cached_property
 from random import choices
 from typing import TYPE_CHECKING, Any, ForwardRef, Optional, Union, cast, overload
 
@@ -491,28 +492,6 @@ class ForeignKeyField(BaseField):  # type: ignore[misc]
             for val in value
         ]
 
-    def _register_existing_model(
-        self, value: "Model", child: "Model", to_register: bool
-    ) -> "Model":
-        """
-        Takes already created instance and registers it for parent.
-        Registration is mutual, so children have also reference to parent.
-
-        Used in reverse FK relations and normal FK for single models.
-
-        :param value: already instantiated Model
-        :type value: Model
-        :param child: child/ related Model
-        :type child: Model
-        :param to_register: flag if the relation should be set in RelationshipManager
-        :type to_register: bool
-        :return: (if needed) registered Model
-        :rtype: Model
-        """
-        if to_register:
-            self.register_relation(model=value, child=child)
-        return value
-
     def _construct_model_from_dict(
         self, value: dict, child: "Model", to_register: bool
     ) -> "Model":
@@ -611,6 +590,23 @@ class ForeignKeyField(BaseField):  # type: ignore[misc]
         """
         return self.to.__class__ == ForwardRef
 
+    @cached_property
+    def _constructor_dispatch(self) -> dict[str, Any]:
+        """
+        Per-field map from input class name to the constructor handling that
+        shape. Built once at first access — by the time
+        ``expand_relationship`` runs, ``_verify_model_can_be_initialized``
+        has already gated on ``requires_ref_update``, so the bound methods
+        captured here are stable.
+
+        :return: dispatch table for the slow path of ``expand_relationship``
+        :rtype: dict[str, Any]
+        """
+        return {
+            "dict": self._construct_model_from_dict,
+            "list": self._extract_model_from_sequence,
+        }
+
     def expand_relationship(
         self,
         value: Any,
@@ -636,20 +632,17 @@ class ForeignKeyField(BaseField):  # type: ignore[misc]
         """
         if value is None:
             return None if not self.virtual else []
-        try:
-            constructors = self._constructors_cache  # type: ignore[has-type]
-        except AttributeError:
-            self._constructors_cache = {
-                self.to.__name__: self._register_existing_model,
-                "dict": self._construct_model_from_dict,
-                "list": self._extract_model_from_sequence,
-            }
-            constructors = self._constructors_cache
-
-        model = constructors.get(  # type: ignore
+        # Fast path: ``value`` is already a Model of ``self.to``. Dominant
+        # case in row materialization and in user kwargs that pass
+        # constructed Models directly. Skips the dispatch table and the
+        # ``_register_existing_model`` indirection entirely.
+        if value.__class__ is self.to:
+            if to_register:
+                self.register_relation(model=value, child=cast("Model", child))
+            return value
+        return self._constructor_dispatch.get(
             value.__class__.__name__, self._construct_model_from_pk
         )(value, child, to_register)
-        return model
 
     def get_relation_name(self) -> str:  # pragma: no cover
         """


### PR DESCRIPTION
## Summary

`ForeignKeyField.expand_relationship` is invoked for every relation field on every `Model.__init__` (twice — once from `_process_kwargs`, once from `_register_related_models`) and again on every `model.related_field = …`. Today the body runs a per-call `try/except AttributeError` framework around a lazily-built constructor cache, then dispatches on `value.__class__.__name__` via a string-keyed dict — even though the dominant case (row materialization and user kwargs that already hold constructed Models) is just "register if asked, return value".

### What changed (`ormar/fields/foreign_key.py` only)

- **Identity-based fast path** before the dispatch table:
  ```python
  if value.__class__ is self.to:
      if to_register:
          self.register_relation(model=value, child=cast("Model", child))
      return value
  ```
  Cheapest possible identity check; catches the dominant path without any dict lookup or `_register_existing_model` indirection.

- **`@cached_property _constructor_dispatch`** replaces the per-call lazy `try/except AttributeError`. By the time `expand_relationship` runs, `_verify_model_can_be_initialized` has already gated on `requires_ref_update`, so `self.to` is resolved and the bound methods captured here are stable.

- **`_register_existing_model` deleted.** Its single role (register if `to_register`, return value) is now inlined in the fast path; the dispatch entry that pointed to it is gone, leaving only `dict` and `list` keys plus the `_construct_model_from_pk` fallback.

- The `child` parameter is `cast("Model", child)` on the fast-path `register_relation` call. The previous code laundered the broader `Union["Model", "NewBaseModel"]` type through the `Any`-typed dispatch dict; calling `register_relation` directly exposed the type mismatch.

### Behavior preserved for non-fast-path inputs

- **Subclasses of `self.to`** — `value.__class__ is self.to` is `False`, falls through to the dispatch table; the subclass `__name__` doesn't match the (deleted) self-class entry, so it lands on `_construct_model_from_pk`. Today's name-keyed dispatch also missed for subclasses → same routing.
- **`to_pk_only` instances** — same routing as today: the dispatch table doesn't have an entry, falls to `_construct_model_from_pk`.
- **`dict` / `list` inputs** — unchanged, still go through `_constructor_dispatch`.
- **Pk-typed inputs** (int, UUID, str) — unchanged, fall through to `_construct_model_from_pk`.

## Benchmarks (sqlite, on-disk; warmup on, min_rounds=10)

vs the post-#1655 optimization tip:

| Workload | Before | After | Δ |
|---|---:|---:|---:|
| `init_with_related[40]` | 858 µs | 810 µs | **−5.6%** |
| `init_with_related[20]` | 446 µs | 418 µs | −6.3% |
| `init_with_related[10]` | 235 µs | 222 µs | −5.5% |
| `init[1000]` | 7010 µs | 6517 µs | **−7.0%** |
| `init[500]` | 3496 µs | 3256 µs | −6.9% |
| `get_all_with_related[40]` | 4351 µs | 4124 µs | **−5.2%** |
| `get_all_with_related[20]` | 2596 µs | 2461 µs | −5.2% |
| `get_all_with_related[10]` | 1786 µs | 1646 µs | −7.8% |
| `get_all[1000]` | 9581 µs | 9218 µs | −3.8% |
| `iterate[1000]` | 17152 µs | 16188 µs | −5.6% |
| `get_one[1000]` (DB-bound) | 768 µs | 671 µs | −12.6% |

Hits the audit's projected 5–8% on the canonical `init_with_related` workload, and the win generalizes — every Model construction that touches `_register_related_models` / `_process_kwargs` benefits.

## Test plan

- [x] `make pre-commit` clean (ruff format, ruff check, mypy)
- [x] `make coverage` at 100%
- [x] `tests/test_relations/`, `tests/test_signals/`, `tests/test_inheritance_and_pydantic_generation/`, `tests/test_model_definition/`, `tests/test_queries/` — all green (389 passed)
- [ ] CI run on PG / MySQL dialects