### PR TITLE
perf: in-place index assignment in _merge_items_lists

### DIFF
--- a/benchmarks/test_benchmark_merge.py
+++ b/benchmarks/test_benchmark_merge.py
@@ -1,0 +1,118 @@
+"""Benchmark for nested-join row merging in ``_process_query_result_rows``.
+
+The workload below targets the path optimized by the in-place index
+assignment in ``_merge_items_lists``: a parent that fans out across many
+joined rows so the matched branch fires repeatedly during
+``_recursive_add``, with both halves of late-round merges accumulating
+overlapping child PKs.
+
+Shape:
+
+    Project (1) -> Task (N, FK) -> Tag (M, m2m, shared across tasks)
+
+A single ``Project`` produces ``N * M`` result rows on
+``select_related(["tasks", "tasks__tags"]).all()``. The pairwise
+``_recursive_add`` consolidates the duplicates, and in the deeper rounds
+both sides hold overlapping ``Task`` PKs (because every adjacent row
+carries the same task with a different tag); inside each task the tag
+lists also accumulate and overlap across recursion halves.
+"""
+
+import pytest
+
+import ormar
+from benchmarks.conftest import base_ormar_config
+
+pytestmark = pytest.mark.asyncio
+
+
+class BenchTag(ormar.Model):
+    ormar_config = base_ormar_config.copy(tablename="bench_merge_tags")
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=50)
+
+
+class BenchProject(ormar.Model):
+    ormar_config = base_ormar_config.copy(tablename="bench_merge_projects")
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+
+
+class BenchTask(ormar.Model):
+    ormar_config = base_ormar_config.copy(tablename="bench_merge_tasks")
+
+    id: int = ormar.Integer(primary_key=True)
+    project: BenchProject = ormar.ForeignKey(
+        BenchProject, index=True, related_name="tasks"
+    )
+    title: str = ormar.String(max_length=100)
+    tags: list[BenchTag] = ormar.ManyToMany(BenchTag)
+
+
+@pytest.mark.parametrize(
+    ("num_tasks", "tags_per_task"),
+    [(5, 5), (10, 10), (20, 10)],
+)
+async def test_select_related_nested_merge(
+    aio_benchmark, num_tasks: int, tags_per_task: int
+):
+    """Project -> Tasks (FK) -> Tags (m2m) workload.
+
+    Result row count is ``num_tasks * tags_per_task`` for one project; every
+    row materializes a duplicate Project with one Task (with one Tag).
+    The merge path consolidates duplicates pairwise via ``_recursive_add``
+    — covers ``_merge_items_lists`` end-to-end through the full join /
+    materialize / merge pipeline.
+    """
+    project = await BenchProject(name="P").save()
+    tags = [await BenchTag(name=f"t{i}").save() for i in range(tags_per_task)]
+    for i in range(num_tasks):
+        task = await BenchTask(project=project, title=f"T{i}").save()
+        for tag in tags:
+            await task.tags.add(tag)
+
+    @aio_benchmark
+    async def query():
+        return await BenchProject.objects.select_related(["tasks", "tasks__tags"]).all()
+
+    result = query()
+    assert len(result) == 1
+    assert len(result[0].tasks) == num_tasks
+    for task in result[0].tasks:
+        assert len(task.tags) == tags_per_task
+
+
+@pytest.mark.parametrize("list_size", [10, 50, 100])
+def test_merge_items_lists_pk_overlap(benchmark, list_size: int):
+    """Microbenchmark for ``_merge_items_lists`` with full PK overlap.
+
+    Constructs two equally sized lists of saved tasks where every entry
+    in ``current_field`` matches an entry in ``other_value`` by PK. This
+    is the worst case the per-pair list rebuild used to be O(N) on — K
+    matches, each filtering an N-element ``value_to_set``. With
+    ``other_idx`` driving in-place writes the cost drops from O(K·N) to
+    O(K).
+
+    The benchmark calls the merge classmethod directly so the SA query /
+    row materialization overhead is excluded — the signal we want is the
+    inner loop only. Every task is fully populated (no relations to
+    recurse into) so ``merge_two_instances`` is light and the
+    ``_merge_items_lists`` body itself dominates.
+    """
+    project = BenchProject(id=1, name="p")
+    current_field = [
+        BenchTask(id=i, project=project, title=f"T{i}") for i in range(list_size)
+    ]
+    other_value = [
+        BenchTask(id=i, project=project, title=f"T{i}") for i in range(list_size)
+    ]
+
+    benchmark(
+        BenchTask._merge_items_lists,
+        field_name="tasks",
+        current_field=current_field,
+        other_value=other_value,
+        relation_map={"tasks": ...},
+    )

--- a/ormar/models/mixins/merge_mixin.py
+++ b/ormar/models/mixins/merge_mixin.py
@@ -172,21 +172,22 @@ class MergeModelMixin:
         other_pks = [getattr(m, "pk", None) for m in other_value]
         plan = ormar_rust_utils.plan_merge_items_lists(current_pks, other_pks)
         value_to_set = list(other_value)
+        nested_relation_map = cast(
+            Optional[dict],
+            skip_ellipsis(relation_map, field_name, default=dict()),
+        )
         for cur_idx, other_idx in plan:
             cur_item = current_field[cur_idx]
             if other_idx is not None:
-                old_value = other_value[other_idx]
-                new_val = cls.merge_two_instances(
+                # ``other_idx`` is the destination slot the Rust planner
+                # already identified — write the merged instance there in
+                # place rather than rebuilding ``value_to_set`` with a pk
+                # filter (which was O(N) per match).
+                value_to_set[other_idx] = cls.merge_two_instances(
                     cur_item,
-                    cast("Model", old_value),
-                    relation_map=cast(
-                        Optional[dict],
-                        skip_ellipsis(relation_map, field_name, default=dict()),
-                    ),
+                    cast("Model", other_value[other_idx]),
+                    relation_map=nested_relation_map,
                 )
-                value_to_set = [
-                    x for x in value_to_set if getattr(x, "pk", None) != cur_item.pk
-                ] + [new_val]
             else:
                 value_to_set.append(cur_item)
         return value_to_set


### PR DESCRIPTION
## Summary

The matched branch in `_merge_items_lists` rebuilt `value_to_set` with a list comprehension that filtered by pk and concatenated `[new_val]` — O(N) per match, O(K·N) overall. The Rust planner (`ormar_rust_utils.plan_merge_items_lists`) already returns the destination index (`other_idx`); use it for an O(1) in-place write.

Two commits:

1. **The optimization** — single-file change in `ormar/models/mixins/merge_mixin.py`.
2. **New benchmark file** — `benchmarks/test_benchmark_merge.py` with an integration test (full pipeline) and a microbenchmark (isolates the inner loop) that produces clean signal.

## Microbenchmark deltas (full PK overlap, calls `_merge_items_lists` directly)

| `list_size` | Baseline (O(K·N)) | After (O(K)) | Δ |
|---:|---:|---:|---:|
| 10 | 31.4 µs | 7.0 µs | **−77.6%** (4.5×) |
| 50 | 531.2 µs | 30.8 µs | **−94.2%** (17×) |
| 100 | 2028.5 µs | 61.8 µs | **−97.0%** (33×) |

Growth confirms the theory: baseline scales quadratically (∼64× from N=10 to N=100), new code scales linearly (∼9×).

## Why the integration benchmark is flat

The existing benchmark suite (and the new integration benchmark in this PR) doesn't visibly move because real query workloads don't usually produce `list_size > 1 with PK overlap` per merge call:

- For `_merge_items_lists` to hit the matched branch with a multi-element `value_to_set`, the query must fan out so the same child PK lands on **both** halves of a pairwise `_recursive_add` merge with multiple matches.
- The standard 1-author-N-books and project-tasks-tags shapes have pairwise merges where `value_to_set` is consistently size 1 at match time, so the old O(K·N) collapses to O(K) anyway.

The change is therefore best understood as:

- A **structural simplification** (less code, no list rebuilding, exact `other_idx` reuse from Rust).
- An **algorithmic guarantee** that the worst case is now O(K) instead of O(K·N).
- The microbenchmark documents and exercises the optimized path so it doesn't regress later.

## Behavior changes (worth highlighting)

Matched items now keep their original `other_value` index instead of being shuffled to the tail. The "shuffle to tail" was an artifact of the rebuild pattern, not a deliberate semantic — `tests/test_ordering/` and the broader test suite (628 passed) all pass unchanged.

## Test plan

- [x] `make pre-commit` clean (ruff format, ruff check, mypy)
- [x] `make coverage` at 100%
- [x] `tests/test_ordering/` (canary for the order behavior change) — all green
- [x] `tests/test_relations/`, `tests/test_signals/`, `tests/test_inheritance_and_pydantic_generation/`, `tests/test_model_definition/`, `tests/test_queries/`, `tests/test_model_methods/` — all green (423 passed)
- [x] New `benchmarks/test_benchmark_merge.py` runs cleanly
- [ ] CI run on PG / MySQL dialects