### PR TITLE
docs: rewrite FilterAction / OrderAction / SelectAction docstrings

### DIFF
--- a/ormar/queryset/actions/filter_action.py
+++ b/ormar/queryset/actions/filter_action.py
@@ -47,12 +47,11 @@ ESCAPE_CHARACTERS = ["%", "_"]
 
 class FilterAction(QueryAction):
     """
-    Filter Actions is populated by queryset when filter() is called.
+    Represents a single WHERE predicate on a queryset.
 
-    All required params are extracted but kept raw until actual filter clause value
-    is required -> then the action is converted into text() clause.
-
-    Extracted in order to easily change table prefixes on complex relations.
+    Created for each ``key=value`` (or ``key__op=value``) passed to
+    ``filter(...)`` / ``exclude(...)`` and to filtering shortcuts like
+    ``get(...)`` / ``first(...)``.
     """
 
     def __init__(self, filter_str: str, value: Any, model_cls: type["Model"]) -> None:

--- a/ormar/queryset/actions/order_action.py
+++ b/ormar/queryset/actions/order_action.py
@@ -12,12 +12,10 @@ if TYPE_CHECKING:  # pragma: nocover
 
 class OrderAction(QueryAction):
     """
-    Order Actions is populated by queryset when order_by() is called.
+    Represents a single ORDER BY directive on a queryset.
 
-    All required params are extracted but kept raw until actual filter clause value
-    is required -> then the action is converted into text() clause.
-
-    Extracted in order to easily change table prefixes on complex relations.
+    Created when ``order_by(...)`` or ``Field.asc()`` / ``Field.desc()`` is
+    used, and internally to apply the default primary-key ordering.
     """
 
     def __init__(

--- a/ormar/queryset/actions/select_action.py
+++ b/ormar/queryset/actions/select_action.py
@@ -11,12 +11,10 @@ if TYPE_CHECKING:  # pragma: no cover
 
 class SelectAction(QueryAction):
     """
-    Order Actions is populated by queryset when order_by() is called.
+    Represents a single column target for an aggregate function on a queryset.
 
-    All required params are extracted but kept raw until actual filter clause value
-    is required -> then the action is converted into text() clause.
-
-    Extracted in order to easily change table prefixes on complex relations.
+    Created when ``.min()`` / ``.max()`` / ``.sum()`` / ``.avg()`` is called,
+    optionally traversing relations via ``__``.
     """
 
     def __init__(self, select_str: str, model_cls: type["Model"]) -> None:


### PR DESCRIPTION
## Summary

The three `QueryAction` subclasses had near-identical, partly inaccurate docstrings:

- `SelectAction`'s was a literal copy of `OrderAction`'s and referenced `order_by()` — which is what #940 reported.
- `OrderAction` / `FilterAction` described themselves as only being created from `order_by()` / `filter()`, even though they also drive default pk ordering, `Field.asc()` / `.desc()`, internal join machinery, and the `get()` / `first()` / `exclude()` filter shortcuts.

Rewrites all three to short, accurate descriptions that reference only public API and don't leak implementation details about how the raw query string is held until SQL build time.

Fixes #940.

## Test plan

- [x] `make pre-commit` (ruff format / lint / mypy) — passes
- Coverage unchanged — docstrings only, no executable code touched