### PR TITLE
Include @computed_field methods in get_pydantic()

### DIFF
--- a/docs/models/methods.md
+++ b/docs/models/methods.md
@@ -361,6 +361,8 @@ Note how `Item` model above does not have a reference to `Category` although in 
     But, at the same time all root validators present on `ormar` models will **NOT** be copied to the generated pydantic model. Since root validator can operate on all fields and a user can exclude some fields during generation of pydantic model it's not safe to copy those validators.
     If required, you need to redefine/ manually copy them to generated pydantic model.
 
+Methods decorated with `@pydantic.computed_field` are also carried over to the generated model and follow the same `include` / `exclude` rules as regular fields, so they appear in the model's schema and `model_dump()` output (e.g. in `fastapi` responses).
+
 ## load()
 
 By default, when you query a table without prefetching related models, the ormar will still construct

--- a/ormar/models/mixins/pydantic_mixin.py
+++ b/ormar/models/mixins/pydantic_mixin.py
@@ -88,6 +88,7 @@ class PydanticMixin(RelationMixin):
             {"__annotations__": fields_dict, **defaults},
         )
         model = cast(type[pydantic.BaseModel], model)
+        cls._copy_computed_fields(model=model, include=include, exclude=exclude)
         cls._copy_field_validators(model=model)
         cls.__cache__[cache_key] = model
         return model
@@ -141,6 +142,39 @@ class PydanticMixin(RelationMixin):
         if field.nullable:
             defaults[name] = None
         return target, defaults
+
+    @classmethod
+    def _copy_computed_fields(
+        cls,
+        model: type[pydantic.BaseModel],
+        include: Optional[dict],
+        exclude: Optional[dict],
+    ) -> None:
+        """
+        Copy ``@pydantic.computed_field`` decorated methods from the ormar model
+        onto the generated pydantic model so they are exposed in the schema and
+        serialization output. Computed fields are filtered with the same
+        include/exclude rules as regular fields.
+
+        :param model: pydantic model generated from the ormar model
+        :type model: type[pydantic.BaseModel]
+        :param include: fields of own and nested models to include
+        :type include: Optional[dict]
+        :param exclude: fields of own and nested models to exclude
+        :type exclude: Optional[dict]
+        """
+        computed_fields = cls.__pydantic_decorators__.computed_fields
+        if not computed_fields:
+            return
+        names_to_copy = filter_not_excluded_fields(
+            fields=set(computed_fields.keys()),
+            include=include,
+            exclude=exclude,
+        )
+        for name in names_to_copy:
+            decorator = computed_fields[name]
+            setattr(model, name, decorator.info.wrapped_property)
+            model.__pydantic_decorators__.computed_fields[name] = copy.copy(decorator)
 
     @classmethod
     def _copy_field_validators(cls, model: type[pydantic.BaseModel]) -> None:

--- a/tests/test_inheritance_and_pydantic_generation/test_geting_pydantic_models.py
+++ b/tests/test_inheritance_and_pydantic_generation/test_geting_pydantic_models.py
@@ -1,6 +1,7 @@
 from typing import ForwardRef, Optional
 
 import pydantic
+from pydantic import computed_field
 from pydantic_core import PydanticUndefined
 
 import ormar
@@ -34,6 +35,33 @@ class Item(ormar.Model):
     id: int = ormar.Integer(primary_key=True)
     name: str = ormar.String(max_length=100, default="test")
     category: Optional[Category] = ormar.ForeignKey(Category, nullable=True)
+
+
+class CommentTopic(ormar.Model):
+    ormar_config = base_ormar_config.copy(tablename="comment_topics")
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+
+    @computed_field
+    def upper_name(self) -> str:
+        return self.name.upper()
+
+
+class Comment(ormar.Model):
+    ormar_config = base_ormar_config.copy(tablename="comments")
+
+    id: int = ormar.Integer(primary_key=True)
+    body: str = ormar.String(max_length=200, default="")
+    topic: Optional[CommentTopic] = ormar.ForeignKey(CommentTopic, nullable=True)
+
+    @computed_field
+    def shouted_body(self) -> str:
+        return self.body.upper()
+
+    @computed_field
+    def trimmed_body(self) -> str:
+        return self.body.strip()
 
 
 class MutualA(ormar.Model):
@@ -303,3 +331,40 @@ def test_getting_pydantic_model_mutual_rels_exclude():
     assert len(MutualB2.model_fields) == 2
     assert set(MutualB2.model_fields.keys()) == {"id", "name"}
     assert MutualB1 != MutualB2
+
+
+def test_getting_pydantic_model_includes_computed_fields():
+    PydanticComment = Comment.get_pydantic()
+    assert set(PydanticComment.model_computed_fields.keys()) == {
+        "shouted_body",
+        "trimmed_body",
+    }
+    instance = PydanticComment(id=1, body=" hi ")
+    dumped = instance.model_dump()
+    assert dumped["shouted_body"] == " HI "
+    assert dumped["trimmed_body"] == "hi"
+
+
+def test_getting_pydantic_model_excludes_computed_field_by_name():
+    PydanticComment = Comment.get_pydantic(exclude={"trimmed_body"})
+    assert set(PydanticComment.model_computed_fields.keys()) == {"shouted_body"}
+    instance = PydanticComment(id=1, body=" hi ")
+    dumped = instance.model_dump()
+    assert "trimmed_body" not in dumped
+    assert dumped["shouted_body"] == " HI "
+
+
+def test_getting_pydantic_model_include_filters_computed_fields():
+    PydanticComment = Comment.get_pydantic(include={"id", "body", "shouted_body"})
+    assert set(PydanticComment.model_fields.keys()) == {"id", "body"}
+    assert set(PydanticComment.model_computed_fields.keys()) == {"shouted_body"}
+
+
+def test_getting_pydantic_model_propagates_computed_fields_through_relations():
+    PydanticComment = Comment.get_pydantic()
+    InnerTopic = PydanticComment.__pydantic_core_schema__["schema"]["fields"]["topic"][
+        "schema"
+    ]["schema"]["schema"]["cls"]
+    assert set(InnerTopic.model_computed_fields.keys()) == {"upper_name"}
+    inner = InnerTopic(id=1, name="news")
+    assert inner.model_dump()["upper_name"] == "NEWS"

--- a/tests/test_inheritance_and_pydantic_generation/test_inheritance_of_property_fields.py
+++ b/tests/test_inheritance_and_pydantic_generation/test_inheritance_of_property_fields.py
@@ -53,3 +53,19 @@ def test_property_fields_are_inherited():
     bar = Bar(name="bar")
     assert bar.prefixed_name == "baz_bar"
     assert bar.model_dump() == {"name": "bar", "id": None, "prefixed_name": "baz_bar"}
+
+
+def test_inherited_property_fields_are_exposed_in_get_pydantic():
+    PydanticFoo = Foo.get_pydantic()
+    assert set(PydanticFoo.model_computed_fields.keys()) == {
+        "prefixed_name",
+        "double_prefixed_name",
+    }
+    foo_dump = PydanticFoo(name="foo").model_dump()
+    assert foo_dump["prefixed_name"] == "prefix_foo"
+    assert foo_dump["double_prefixed_name"] == "prefix2_foo"
+
+    PydanticBar = Bar.get_pydantic()
+    assert set(PydanticBar.model_computed_fields.keys()) == {"prefixed_name"}
+    bar_dump = PydanticBar(name="bar").model_dump()
+    assert bar_dump["prefixed_name"] == "baz_bar"


### PR DESCRIPTION
## Summary
- `get_pydantic()` now copies `@pydantic.computed_field` methods from the ormar model onto the generated pydantic model, so they appear in the schema and `model_dump()` output (e.g. in FastAPI responses).
- Computed fields respect the same `include` / `exclude` rules as regular fields.
- Added tests covering default inclusion, exclude-by-name, include-only-some, propagation through a relation, and inheritance/override.
- Short docs note added under `get_pydantic()` in `docs/models/methods.md`.

Closes #939.

## Test plan
- [x] `make pre-commit` (ruff format, ruff check, mypy) clean
- [x] `make coverage` — 633 passed, 100.00% coverage
- [ ] CI green across SQLite / MySQL / PostgreSQL