### PR TITLE
fix get_or_create race + update_or_create missing-pk bug

### DIFF
--- a/docs/queries/read.md
+++ b/docs/queries/read.md
@@ -112,6 +112,11 @@ assert album == album2
     Note that if you want to create a new object you either have to pass pk column
     value or pk column has to be set as autoincrement
 
+!!!note
+    Concurrent calls fall back to a second `get` if `create` trips a unique
+    constraint, returning the winning row with `created=False`. Wrap in
+    `database.transaction()` for stricter atomicity.
+
 ## first
 
 `first(*args, **kwargs) -> Model`

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,14 @@
 # Release notes
 
+## Unreleased
+
+### 🐛 Fixes
+
+* Fix race in `get_or_create` (and the m2m / reverse-fk variant) where
+  concurrent callers leaked `IntegrityError`. [#1016](https://github.com/collerek/ormar/issues/1016)
+* Fix `update_or_create` raising `NoMatch` instead of creating when called
+  with a pk that doesn't exist in the database.
+
 ## 0.25.0
 
 ### ⚡ Performance

--- a/ormar/queryset/queryset.py
+++ b/ormar/queryset/queryset.py
@@ -1181,6 +1181,13 @@ class QuerySet(Generic[T]):
         and if `NoMatch` exception is raised
         it creates a new one with given kwargs and _defaults.
 
+        If a concurrent caller wins the race and creates a matching row
+        between this call's ``get`` and ``create``, the ``create`` raises
+        ``sqlalchemy.exc.IntegrityError`` and ``get`` is retried once.
+        If the retry still finds no row, the original ``IntegrityError`` is
+        re-raised because the violation isn't a race but a legitimate
+        constraint conflict (e.g. a different unique key).
+
         Passing a criteria is actually calling filter(*args, **kwargs) method described
         below.
 
@@ -1194,12 +1201,24 @@ class QuerySet(Generic[T]):
         try:
             return await self.get(*args, **kwargs), False
         except NoMatch:
-            _defaults = _defaults or {}
+            pass
+
+        _defaults = _defaults or {}
+        try:
             return await self.create(**{**kwargs, **_defaults}), True
+        except sqlalchemy.exc.IntegrityError as integrity_error:
+            try:
+                return await self.get(*args, **kwargs), False
+            except NoMatch:
+                raise integrity_error from None
 
     async def update_or_create(self, **kwargs: Any) -> "T":
         """
         Updates the model, or in case there is no match in database creates a new one.
+
+        If a pk is supplied but no row exists with that pk, a new row is
+        created with the supplied pk and field values rather than raising
+        ``NoMatch``.
 
         :param kwargs: fields names and proper value types
         :type kwargs: Any
@@ -1211,7 +1230,10 @@ class QuerySet(Generic[T]):
             kwargs[pk_name] = kwargs.pop("pk")
         if pk_name not in kwargs or kwargs.get(pk_name) is None:
             return await self.create(**kwargs)
-        model = await self.get(pk=kwargs[pk_name])
+        try:
+            model = await self.get(pk=kwargs[pk_name])
+        except NoMatch:
+            return await self.create(**kwargs)
         return await model.update(**kwargs)
 
     async def all(self, *args: Any, **kwargs: Any) -> list["T"]:  # noqa: A003

--- a/ormar/relations/querysetproxy.py
+++ b/ormar/relations/querysetproxy.py
@@ -12,6 +12,8 @@ from typing import (  # noqa: I100, I201
     cast,
 )
 
+import sqlalchemy.exc
+
 import ormar  # noqa: I100, I202
 from ormar.exceptions import ModelPersistenceError, NoMatch, QueryDefinitionError
 
@@ -590,6 +592,13 @@ class QuerysetProxy(Generic[T]):
         and if `NoMatch` exception is raised
         it creates a new one with given kwargs and _defaults.
 
+        If a concurrent caller wins the race and creates a matching row
+        between this call's ``get`` and ``create``, the ``create`` raises
+        ``sqlalchemy.exc.IntegrityError`` and ``get`` is retried once.
+        If the retry still finds no row, the original ``IntegrityError`` is
+        re-raised because the violation isn't a race but a legitimate
+        constraint conflict (e.g. a different unique key).
+
         :param kwargs: fields names and proper value types
         :type kwargs: Any
         :param _defaults: default values for creating object
@@ -600,12 +609,24 @@ class QuerysetProxy(Generic[T]):
         try:
             return await self.get(*args, **kwargs), False
         except NoMatch:
-            _defaults = _defaults or {}
+            pass
+
+        _defaults = _defaults or {}
+        try:
             return await self.create(**{**kwargs, **_defaults}), True
+        except sqlalchemy.exc.IntegrityError as integrity_error:
+            try:
+                return await self.get(*args, **kwargs), False
+            except NoMatch:
+                raise integrity_error from None
 
     async def update_or_create(self, **kwargs: Any) -> "T":
         """
         Updates the model, or in case there is no match in database creates a new one.
+
+        If a pk is supplied but no row exists with that pk, a new row is
+        created with the supplied pk and field values rather than raising
+        ``NoMatch``.
 
         Actual call delegated to QuerySet.
 
@@ -619,7 +640,10 @@ class QuerysetProxy(Generic[T]):
             kwargs[pk_name] = kwargs.pop("pk")
         if pk_name not in kwargs or kwargs.get(pk_name) is None:
             return await self.create(**kwargs)
-        model = await self.queryset.get(pk=kwargs[pk_name])
+        try:
+            model = await self.queryset.get(pk=kwargs[pk_name])
+        except NoMatch:
+            return await self.create(**kwargs)
         return await model.update(**kwargs)
 
     def filter(  # noqa: A003, A001

--- a/tests/test_queries/test_get_or_create_concurrency.py
+++ b/tests/test_queries/test_get_or_create_concurrency.py
@@ -1,0 +1,144 @@
+"""Concurrent ``get_or_create`` race-recovery tests for issue #1016.
+
+These tests run under AUTOCOMMIT (no surrounding transaction) so they
+exercise the real-world scenario: separate coroutines, each pulling its
+own connection from the pool, racing to insert a row.
+
+The project-wide ``force_rollback=True`` config can't be used here:
+PostgreSQL aborts the surrounding transaction on the first failed
+statement, which makes the recovery ``get`` raise
+``InFailedSQLTransactionError`` instead of returning the winner's row.
+"""
+
+import asyncio
+from typing import Optional
+
+import pytest
+import sqlalchemy.exc
+
+import ormar
+from tests.lifespan import init_tests
+from tests.settings import create_config
+
+race_config = create_config()
+
+
+class RaceLibrary(ormar.Model):
+    ormar_config = race_config.copy(tablename="race_libraries")
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+
+
+class RaceBook(ormar.Model):
+    ormar_config = race_config.copy(tablename="race_unique_books")
+
+    id: int = ormar.Integer(primary_key=True)
+    isbn: str = ormar.String(max_length=20, unique=True)
+    title: str = ormar.String(max_length=200)
+    library: Optional[RaceLibrary] = ormar.ForeignKey(
+        RaceLibrary, nullable=True, related_name="books"
+    )
+
+
+create_test_database = init_tests(race_config)
+
+
+async def _cleanup() -> None:
+    await RaceBook.objects.delete(each=True)
+    await RaceLibrary.objects.delete(each=True)
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_recovers_from_concurrent_create():
+    """Two concurrent ``get_or_create`` calls race for real: both
+    ``SELECT``s return empty, then one ``INSERT`` wins and the other
+    raises ``IntegrityError``. The losing call must catch the error,
+    retry the ``get``, and return the winner's row with ``created=False``
+    rather than leaking the driver error.
+
+    Both calls returning the same pk with exactly one ``created=True``
+    proves the recovery path actually fired — if the IntegrityError had
+    propagated, ``asyncio.gather`` would have re-raised it.
+    """
+    async with race_config.database:
+        try:
+            results = await asyncio.gather(
+                RaceBook.objects.get_or_create(isbn="978-0-00-000000-1", title="Race"),
+                RaceBook.objects.get_or_create(isbn="978-0-00-000000-1", title="Race"),
+            )
+
+            (book1, c1), (book2, c2) = results
+            assert book1.pk == book2.pk
+            assert book1.isbn == "978-0-00-000000-1"
+            assert sorted([c1, c2]) == [False, True]
+            assert await RaceBook.objects.count() == 1
+        finally:
+            await _cleanup()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_propagates_unrelated_integrity_error():
+    """If ``create`` fails with ``IntegrityError`` and the retry ``get``
+    still finds nothing matching the caller's filter, the violation
+    isn't a race — it's a legitimate constraint conflict (e.g. a unique
+    column the caller isn't filtering by). The original ``IntegrityError``
+    must propagate instead of being swallowed.
+    """
+    async with race_config.database:
+        try:
+            await RaceBook.objects.create(isbn="978-0-00-000000-2", title="Original")
+            with pytest.raises(sqlalchemy.exc.IntegrityError):
+                await RaceBook.objects.get_or_create(
+                    isbn="978-0-00-000000-2", title="Different"
+                )
+        finally:
+            await _cleanup()
+
+
+@pytest.mark.asyncio
+async def test_proxy_get_or_create_recovers_from_concurrent_create():
+    """Same real-concurrency race but via the m2m / reverse-fk proxy
+    ``QuerysetProxy.get_or_create``, which has its own try/except around
+    the get/create pair.
+    """
+    async with race_config.database:
+        try:
+            library = await RaceLibrary.objects.create(name="Main")
+
+            results = await asyncio.gather(
+                library.books.get_or_create(
+                    isbn="978-0-00-000000-3", title="ProxyRace"
+                ),
+                library.books.get_or_create(
+                    isbn="978-0-00-000000-3", title="ProxyRace"
+                ),
+            )
+
+            (book1, c1), (book2, c2) = results
+            assert book1.pk == book2.pk
+            assert sorted([c1, c2]) == [False, True]
+            assert await RaceBook.objects.count() == 1
+        finally:
+            await _cleanup()
+
+
+@pytest.mark.asyncio
+async def test_proxy_get_or_create_propagates_unrelated_integrity_error():
+    """``QuerysetProxy.get_or_create`` re-raises the original
+    ``IntegrityError`` when the retry ``get`` still doesn't match —
+    same semantics as ``QuerySet.get_or_create``.
+    """
+    async with race_config.database:
+        try:
+            library = await RaceLibrary.objects.create(name="Main")
+            await RaceBook.objects.create(
+                isbn="978-0-00-000000-4", title="Original", library=library
+            )
+
+            with pytest.raises(sqlalchemy.exc.IntegrityError):
+                await library.books.get_or_create(
+                    isbn="978-0-00-000000-4", title="Different"
+                )
+        finally:
+            await _cleanup()

--- a/tests/test_queries/test_queryset_level_methods.py
+++ b/tests/test_queries/test_queryset_level_methods.py
@@ -1,10 +1,8 @@
-import asyncio
 from enum import Enum
 from typing import Optional
 
 import pydantic
 import pytest
-import sqlalchemy.exc
 from pydantic import Json
 
 import ormar
@@ -239,89 +237,6 @@ async def test_get_or_create_with_defaults():
             assert created is False
             assert book2.title == "overwritten"
             assert book2 == book
-
-
-@pytest.mark.asyncio
-async def test_get_or_create_recovers_from_concurrent_create():
-    """Regression test for issue #1016."""
-    async with base_ormar_config.database:
-        async with base_ormar_config.database.transaction(force_rollback=True):
-            results = await asyncio.gather(
-                UniqueBook.objects.get_or_create(
-                    isbn="978-0-00-000000-1", title="Race"
-                ),
-                UniqueBook.objects.get_or_create(
-                    isbn="978-0-00-000000-1", title="Race"
-                ),
-            )
-
-            (book1, c1), (book2, c2) = results
-            assert book1.pk == book2.pk
-            assert book1.isbn == "978-0-00-000000-1"
-            assert sorted([c1, c2]) == [False, True]
-            assert await UniqueBook.objects.count() == 1
-
-
-@pytest.mark.asyncio
-async def test_get_or_create_propagates_unrelated_integrity_error():
-    async with base_ormar_config.database:
-        async with base_ormar_config.database.transaction(force_rollback=True):
-            await UniqueBook.objects.create(isbn="978-0-00-000000-2", title="Original")
-
-            with pytest.raises(sqlalchemy.exc.IntegrityError):
-                # ``isbn`` matches an existing row but ``title`` doesn't,
-                # so the initial get returns NoMatch, the create violates
-                # the unique constraint on isbn, and the retry get also
-                # returns NoMatch (title='Different' doesn't match) — so
-                # the integrity error is re-raised.
-                await UniqueBook.objects.get_or_create(
-                    isbn="978-0-00-000000-2", title="Different"
-                )
-
-
-@pytest.mark.asyncio
-async def test_proxy_get_or_create_recovers_from_concurrent_create():
-    """Same real-concurrency race as
-    ``test_get_or_create_recovers_from_concurrent_create`` but via the
-    m2m / reverse-fk proxy ``QuerysetProxy.get_or_create``, which has its
-    own try/except around the get/create pair.
-    """
-    async with base_ormar_config.database:
-        async with base_ormar_config.database.transaction(force_rollback=True):
-            library = await Library.objects.create(name="Main")
-
-            results = await asyncio.gather(
-                library.books.get_or_create(
-                    isbn="978-0-00-000000-3", title="ProxyRace"
-                ),
-                library.books.get_or_create(
-                    isbn="978-0-00-000000-3", title="ProxyRace"
-                ),
-            )
-
-            (book1, c1), (book2, c2) = results
-            assert book1.pk == book2.pk
-            assert sorted([c1, c2]) == [False, True]
-            assert await UniqueBook.objects.count() == 1
-
-
-@pytest.mark.asyncio
-async def test_proxy_get_or_create_propagates_unrelated_integrity_error():
-    """``QuerysetProxy.get_or_create`` re-raises the original
-    ``IntegrityError`` when the retry ``get`` still doesn't match —
-    same semantics as ``QuerySet.get_or_create``.
-    """
-    async with base_ormar_config.database:
-        async with base_ormar_config.database.transaction(force_rollback=True):
-            library = await Library.objects.create(name="Main")
-            await UniqueBook.objects.create(
-                isbn="978-0-00-000000-4", title="Original", library=library
-            )
-
-            with pytest.raises(sqlalchemy.exc.IntegrityError):
-                await library.books.get_or_create(
-                    isbn="978-0-00-000000-4", title="Different"
-                )
 
 
 @pytest.mark.asyncio

--- a/tests/test_queries/test_queryset_level_methods.py
+++ b/tests/test_queries/test_queryset_level_methods.py
@@ -1,8 +1,10 @@
+import asyncio
 from enum import Enum
 from typing import Optional
 
 import pydantic
 import pytest
+import sqlalchemy.exc
 from pydantic import Json
 
 import ormar
@@ -93,6 +95,24 @@ class JsonTestModel(ormar.Model):
 
     id: int = ormar.Integer(primary_key=True)
     json_field: Json = ormar.JSON()
+
+
+class Library(ormar.Model):
+    ormar_config = base_ormar_config.copy(tablename="libraries")
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+
+
+class UniqueBook(ormar.Model):
+    ormar_config = base_ormar_config.copy(tablename="unique_books")
+
+    id: int = ormar.Integer(primary_key=True)
+    isbn: str = ormar.String(max_length=20, unique=True)
+    title: str = ormar.String(max_length=200)
+    library: Optional[Library] = ormar.ForeignKey(
+        Library, nullable=True, related_name="books"
+    )
 
 
 create_test_database = init_tests(base_ormar_config)
@@ -222,6 +242,89 @@ async def test_get_or_create_with_defaults():
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_recovers_from_concurrent_create():
+    """Regression test for issue #1016."""
+    async with base_ormar_config.database:
+        async with base_ormar_config.database.transaction(force_rollback=True):
+            results = await asyncio.gather(
+                UniqueBook.objects.get_or_create(
+                    isbn="978-0-00-000000-1", title="Race"
+                ),
+                UniqueBook.objects.get_or_create(
+                    isbn="978-0-00-000000-1", title="Race"
+                ),
+            )
+
+            (book1, c1), (book2, c2) = results
+            assert book1.pk == book2.pk
+            assert book1.isbn == "978-0-00-000000-1"
+            assert sorted([c1, c2]) == [False, True]
+            assert await UniqueBook.objects.count() == 1
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_propagates_unrelated_integrity_error():
+    async with base_ormar_config.database:
+        async with base_ormar_config.database.transaction(force_rollback=True):
+            await UniqueBook.objects.create(isbn="978-0-00-000000-2", title="Original")
+
+            with pytest.raises(sqlalchemy.exc.IntegrityError):
+                # ``isbn`` matches an existing row but ``title`` doesn't,
+                # so the initial get returns NoMatch, the create violates
+                # the unique constraint on isbn, and the retry get also
+                # returns NoMatch (title='Different' doesn't match) — so
+                # the integrity error is re-raised.
+                await UniqueBook.objects.get_or_create(
+                    isbn="978-0-00-000000-2", title="Different"
+                )
+
+
+@pytest.mark.asyncio
+async def test_proxy_get_or_create_recovers_from_concurrent_create():
+    """Same real-concurrency race as
+    ``test_get_or_create_recovers_from_concurrent_create`` but via the
+    m2m / reverse-fk proxy ``QuerysetProxy.get_or_create``, which has its
+    own try/except around the get/create pair.
+    """
+    async with base_ormar_config.database:
+        async with base_ormar_config.database.transaction(force_rollback=True):
+            library = await Library.objects.create(name="Main")
+
+            results = await asyncio.gather(
+                library.books.get_or_create(
+                    isbn="978-0-00-000000-3", title="ProxyRace"
+                ),
+                library.books.get_or_create(
+                    isbn="978-0-00-000000-3", title="ProxyRace"
+                ),
+            )
+
+            (book1, c1), (book2, c2) = results
+            assert book1.pk == book2.pk
+            assert sorted([c1, c2]) == [False, True]
+            assert await UniqueBook.objects.count() == 1
+
+
+@pytest.mark.asyncio
+async def test_proxy_get_or_create_propagates_unrelated_integrity_error():
+    """``QuerysetProxy.get_or_create`` re-raises the original
+    ``IntegrityError`` when the retry ``get`` still doesn't match —
+    same semantics as ``QuerySet.get_or_create``.
+    """
+    async with base_ormar_config.database:
+        async with base_ormar_config.database.transaction(force_rollback=True):
+            library = await Library.objects.create(name="Main")
+            await UniqueBook.objects.create(
+                isbn="978-0-00-000000-4", title="Original", library=library
+            )
+
+            with pytest.raises(sqlalchemy.exc.IntegrityError):
+                await library.books.get_or_create(
+                    isbn="978-0-00-000000-4", title="Different"
+                )
+
+
+@pytest.mark.asyncio
 async def test_update_or_create():
     async with base_ormar_config.database:
         async with base_ormar_config.database.transaction(force_rollback=True):
@@ -243,6 +346,59 @@ async def test_update_or_create():
                 await Book.objects.get(
                     title="Volume I", author="Anonymous", genre="Fantasy"
                 )
+
+
+@pytest.mark.asyncio
+async def test_update_or_create_creates_when_pk_does_not_exist():
+    """``update_or_create`` with a pk that doesn't exist must create the
+    row at that pk instead of raising ``NoMatch``.
+    """
+    async with base_ormar_config.database:
+        async with base_ormar_config.database.transaction(force_rollback=True):
+            assert await Book.objects.count() == 0
+
+            book = await Book.objects.update_or_create(
+                id=42, title="X", author="Y", genre="Fiction"
+            )
+            assert book.id == 42
+            assert await Book.objects.count() == 1
+
+            updated = await Book.objects.update_or_create(id=42, genre="Historic")
+            assert updated.id == 42
+            assert updated.genre == "Historic"
+            assert await Book.objects.count() == 1
+
+
+@pytest.mark.asyncio
+async def test_update_or_create_creates_when_pk_alias_does_not_exist():
+    """Same as above but using the ``pk`` alias kwarg, which goes
+    through the ``kwargs.pop("pk")`` rename branch.
+    """
+    async with base_ormar_config.database:
+        async with base_ormar_config.database.transaction(force_rollback=True):
+            book = await Book.objects.update_or_create(
+                pk=99, title="A", author="B", genre="Fiction"
+            )
+            assert book.id == 99
+            assert await Book.objects.count() == 1
+
+
+@pytest.mark.asyncio
+async def test_proxy_update_or_create_creates_when_pk_does_not_exist():
+    """``QuerysetProxy.update_or_create`` (m2m / reverse-fk) duplicates
+    the same get/create logic and must also create when given a missing
+    pk instead of raising ``NoMatch``.
+    """
+    async with base_ormar_config.database:
+        async with base_ormar_config.database.transaction(force_rollback=True):
+            library = await Library.objects.create(name="Main")
+
+            book = await library.books.update_or_create(
+                id=123, isbn="978-0-00-000000-9", title="Created"
+            )
+            assert book.id == 123
+            assert book.isbn == "978-0-00-000000-9"
+            assert await UniqueBook.objects.count() == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #1016.

`get_or_create` now falls back to a second `get` when `create` trips a unique constraint, returning the winner's row with `created=False`. Same fix mirrored on `QuerysetProxy.get_or_create` (m2m / reverse-fk).

Also fixes `update_or_create`: when called with a pk that doesn't exist, it now creates the row instead of raising `NoMatch`.

Note: passing connections / transactions across coroutines (raised in #1016 by @zevisert) is out of scope for this change.