### PR TITLE
make orjson a required dependency

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -46,14 +46,6 @@ pip install ormar[sqlite]
 
 Will install also `aiosqlite`.
 
-### Orjson
-
-```py
-pip install ormar[orjson]
-```
-
-Will install also `orjson` that is much faster than builtin json parser.
-
 ### Crypto
 
 ```py

--- a/ormar/fields/parsers.py
+++ b/ormar/fields/parsers.py
@@ -3,14 +3,10 @@ import decimal
 import uuid
 from typing import Callable, Optional
 
+import orjson as json
 import ormar_rust_utils
 import pydantic
 from pydantic_core import SchemaValidator, core_schema
-
-try:
-    import orjson as json
-except ImportError:  # pragma: no cover
-    import json  # type: ignore
 
 
 def parse_bool(value: str) -> bool:

--- a/ormar/models/helpers/validation.py
+++ b/ormar/models/helpers/validation.py
@@ -2,11 +2,6 @@ import decimal
 import numbers
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
-try:
-    import orjson as json
-except ImportError:  # pragma: no cover
-    import json  # type: ignore  # noqa: F401
-
 import pydantic
 
 from ormar.models.helpers.models import config_field_not_set

--- a/poetry.lock
+++ b/poetry.lock
@@ -1713,10 +1713,9 @@ files = [
 name = "orjson"
 version = "3.11.9"
 description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
-optional = true
+optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"orjson\" or extra == \"all\""
 files = [
     {file = "orjson-3.11.9-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:135869ef917b8704ea0a94e01620e0c05021c15c52036e4663baffe75e72f8ce"},
     {file = "orjson-3.11.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:115ab5f5f4a0f203cc2a5f0fb09aee503a3f771aa08392949ab5ca230c4fbdbd"},
@@ -3129,10 +3128,9 @@ test = ["gevent (>=20.6.2)"]
 
 [extras]
 aiopg = ["aiopg", "psycopg2-binary"]
-all = ["PyMySQL", "aiomysql", "aiopg", "aiosqlite", "asyncpg", "cryptography", "mysqlclient", "orjson", "psycopg2-binary"]
+all = ["PyMySQL", "aiomysql", "aiopg", "aiosqlite", "asyncpg", "cryptography", "mysqlclient", "psycopg2-binary"]
 crypto = ["cryptography"]
 mysql = ["PyMySQL", "aiomysql"]
-orjson = ["orjson"]
 postgres = ["asyncpg", "psycopg2-binary"]
 postgresql = ["asyncpg", "psycopg2-binary"]
 sqlite = ["aiosqlite"]
@@ -3140,4 +3138,4 @@ sqlite = ["aiosqlite"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.0"
-content-hash = "24c5baf41b4913764cb9686979371e82d0dc18f3e4cff5f9da27e7648a4a179c"
+content-hash = "0d53cffb9d62686adedba131d270c93777c4d08a5dca330151ac65f39daa572b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,7 @@ psycopg2-binary = { version = "^2.9.1", optional = true }
 mysqlclient = { version = "^2.1.0", optional = true }
 PyMySQL = { version = "^1.1.0", optional = true }
 ormar-utils = ">=0.1.1"
-
-
-[tool.poetry.dependencies.orjson]
-version = ">=3.6.4"
-optional = true
+orjson = ">=3.6.4"
 
 
 [tool.poetry.extras]
@@ -69,7 +65,6 @@ postgres = ["asyncpg", "psycopg2-binary"]
 aiopg = ["aiopg", "psycopg2-binary"]
 mysql = ["aiomysql", "PyMySQL"]
 sqlite = ["aiosqlite"]
-orjson = ["orjson"]
 crypto = ["cryptography"]
 all = [
     "aiosqlite",
@@ -79,7 +74,6 @@ all = [
     "aiomysql",
     "mysqlclient",
     "PyMySQL",
-    "orjson",
     "cryptography",
 ]
 


### PR DESCRIPTION
## Summary
- Promote `orjson` from optional extra to a regular runtime dependency
- Drop the `orjson` extra and remove the `try/except ImportError` JSON-import shims
- Update install docs accordingly