### PR TITLE
ship tests in sdist (closes #698)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ documentation = "https://ormar-orm.github.io/ormar/"
 packages = [
     { include="ormar" }
 ]
+include = [
+    { path = "tests/**/*.py", format = "sdist" },
+]
 keywords = [
     "orm",
     "sqlalchemy",


### PR DESCRIPTION
Include the `tests/` tree in the source distribution so downstream packagers (FreeBSD ports, Debian, conda-forge, etc.) can run the suite during packaging. Wheel is unaffected.

Resolve: https://github.com/ormar-orm/ormar/issues/698