### PR TITLE
fix: drop unmentioned related columns from values()/values_list()

### DIFF
--- a/docs/queries/raw-data.md
+++ b/docs/queries/raw-data.md
@@ -134,7 +134,18 @@ assert user == [
 
 Combine select related and fields to select only 3 fields.
 
-Note that we also exclude through model as by definition every model included in a join but without any reference in fields is assumed to be selected in full (all fields included).
+!!!note
+    `values()` and `values_list()` project only the columns referenced in
+    `fields()`. Related models pulled into the query (either via
+    `select_related()` directly, or implicitly by a filter like
+    `filter(category__id=1)`) but never named in `fields()` are dropped
+    from the result - including their through models for many-to-many
+    relations.
+
+    This differs from `fields()` on a regular ORM-loading query (`get`,
+    `all`, etc.), where unmentioned related models in `select_related()`
+    are still loaded in full so model construction does not lose
+    mandatory columns.
 
 !!!note
     Note that in contrary to other queryset methods here you can exclude the
@@ -274,7 +285,18 @@ news = await Category(name="News", sort_order=0, created_by=creator).save()
 
 Combine select related and fields to select only 3 fields.
 
-Note that we also exclude through model as by definition every model included in a join but without any reference in fields is assumed to be selected in full (all fields included).
+!!!note
+    `values()` and `values_list()` project only the columns referenced in
+    `fields()`. Related models pulled into the query (either via
+    `select_related()` directly, or implicitly by a filter like
+    `filter(category__id=1)`) but never named in `fields()` are dropped
+    from the result - including their through models for many-to-many
+    relations.
+
+    This differs from `fields()` on a regular ORM-loading query (`get`,
+    `all`, etc.), where unmentioned related models in `select_related()`
+    are still loaded in full so model construction does not lose
+    mandatory columns.
 
 !!!note
     Note that in contrary to other queryset methods here you can exclude the

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,6 +8,12 @@
   concurrent callers leaked `IntegrityError`. [#1016](https://github.com/collerek/ormar/issues/1016)
 * Fix `update_or_create` raising `NoMatch` instead of creating when called
   with a pk that doesn't exist in the database.
+* Fix `values()` / `values_list()` leaking columns of related models that
+  were pulled in by a filter (e.g. `filter(project__id=...)`) or by a bare
+  `select_related()` but never named in `fields()`. Such relations - and
+  their through models for m2m - are now excluded from the projected
+  result, matching the columns the caller actually requested.
+  [#800](https://github.com/collerek/ormar/issues/800)
 
 ## 0.25.0
 

--- a/ormar/models/excludable.py
+++ b/ormar/models/excludable.py
@@ -284,6 +284,21 @@ class Excludable:
         """
         return (... in self.include or key in self.include) if self.include else True
 
+    def is_explicitly_included(self, key: str) -> bool:
+        """
+        Check whether ``key`` is explicitly named in the include set.
+
+        Unlike :meth:`is_included`, this returns ``False`` for an empty
+        include set rather than ``True`` - callers asking "did the user
+        name this?" want a no when nothing was specified at all.
+
+        :param key: key to check
+        :type key: str
+        :return: True if include is non-empty and contains key (or ``...``)
+        :rtype: bool
+        """
+        return bool(self.include) and self.is_included(key)
+
     def is_excluded(self, key: str) -> bool:
         """
         Check if field in excluded (in set or set is {...}).
@@ -363,6 +378,102 @@ class ExcludableItems:
             )
         return self._flatten_map_cache
 
+    @staticmethod
+    def _make_key(model_cls: type["Model"], alias: str = "") -> str:
+        """
+        Build the items-dict key for ``(alias, model)``. Centralized so
+        every call site shares one definition of "which Excludable is
+        this".
+        """
+        prefix = f"{alias}_" if alias else ""
+        return f"{prefix}{model_cls.get_name(lower=True)}"
+
+    @staticmethod
+    def _resolve_path(
+        source_model: type["Model"],
+        parts_prefix: tuple,
+    ) -> tuple[str, type["Model"]]:
+        """
+        Resolve a dunder path prefix to its target ``(alias, model)``.
+
+        An empty prefix returns ``("", source_model)``. Goes through
+        :func:`get_relationship_alias_model_and_str`, which mutates its
+        ``related_parts`` argument while resolving through models - the
+        prefix tuple is copied to a list to insulate the caller.
+
+        Examples (alias strings are hashes from the alias manager and
+        shown here as ``<...>`` since they are not stable across runs)::
+
+            _resolve_path(Post, ())
+            # => ("", Post)
+
+            _resolve_path(Post, ("category",))
+            # => ("<post_category>", Category)
+
+            _resolve_path(Role, ("users", "categories"))
+            # => ("<usercategory_category>", Category)
+
+        :param source_model: model from which the path is rooted
+        :type source_model: type[Model]
+        :param parts_prefix: pre-split path segments
+        :type parts_prefix: tuple
+        :return: alias and target model at the prefix
+        :rtype: tuple[str, type[Model]]
+        """
+        if not parts_prefix:
+            return "", source_model
+        alias, model, _, _ = get_relationship_alias_model_and_str(
+            source_model=source_model,
+            related_parts=list(parts_prefix),
+        )
+        return alias, model
+
+    def _referenced_at(
+        self,
+        source_model: type["Model"],
+        parts_prefix: tuple,
+    ) -> bool:
+        """
+        Return whether this :class:`ExcludableItems` already carries any
+        include or exclude entry for the model at ``parts_prefix``.
+
+        Used by :meth:`with_projection_exclusions` to detect whether the
+        user's ``fields()`` call referenced a given path - an empty
+        ``Excludable`` (or none at all) means "not referenced".
+
+        Examples, contrasting the same path under two different
+        ``fields()`` specs::
+
+            # Built from Post.objects.fields(["name"])
+            #   items = {"post": Excludable(include={"name"})}
+
+            excludable._referenced_at(Post, ())
+            # => True   (Post has a non-empty include)
+
+            excludable._referenced_at(Post, ("category",))
+            # => False  (no entry for Category)
+
+
+            # Built from Post.objects.fields(["name", "category__name"])
+            #   items = {
+            #       "post": Excludable(include={"name"}),
+            #       "<alias>_category": Excludable(include={"name"}),
+            #   }
+
+            excludable._referenced_at(Post, ("category",))
+            # => True   (Category has a non-empty include)
+
+        :param source_model: model from which the path is rooted
+        :type source_model: type[Model]
+        :param parts_prefix: pre-split path segments to check
+        :type parts_prefix: tuple
+        :return: True if a non-empty entry exists at the prefix
+        :rtype: bool
+        """
+        alias, model = self._resolve_path(source_model, parts_prefix)
+        exc = self.items.get(self._make_key(model, alias))
+        return exc is not None and bool(exc.include or exc.exclude)
+
     def get(self, model_cls: type["Model"], alias: str = "") -> Excludable:
         """
         Return Excludable for given model and alias.
@@ -374,7 +485,7 @@ class ExcludableItems:
         :return: Excludable for given model and alias
         :rtype: ormar.models.excludable.Excludable
         """
-        key = f"{alias + '_' if alias else ''}{model_cls.get_name(lower=True)}"
+        key = self._make_key(model_cls, alias)
         excludable = self.items.get(key)
         if not excludable:
             excludable = Excludable()
@@ -457,7 +568,7 @@ class ExcludableItems:
                 self._flatten_paths.add(path_parts + (item,))
             self._flatten_map_cache = None
 
-        key = f"{alias + '_' if alias else ''}{model_cls.get_name(lower=True)}"
+        key = self._make_key(model_cls, alias)
         excludable = self.items.setdefault(key, Excludable())
         excludable.set_values(value=items, slot=slot)
 
@@ -619,6 +730,63 @@ class ExcludableItems:
                     f"so nested flatten '{join_path(longer)}' is unreachable."
                 )
 
+    def with_projection_exclusions(
+        self,
+        source_model: type["Model"],
+        select_related: list[str],
+    ) -> "ExcludableItems":
+        """
+        Return a copy with relations not referenced by ``fields()`` removed
+        from a flat values projection.
+
+        A filter like ``filter(project__id=...)`` auto-joins ``project``;
+        without this, a flat ``values()`` call leaks every Project column
+        even though only one main-model field was requested. Returns the
+        original instance unchanged when ``fields()`` was never called -
+        the leak is a values-projection problem, not an ORM-load problem.
+
+        :param source_model: model from which relation paths are rooted
+        :type source_model: type[Model]
+        :param select_related: paths joined into the query (dunder strings)
+        :type select_related: list[str]
+        :return: new :class:`ExcludableItems` with implicit excludes added,
+            or ``self`` when no ``fields()`` call had any effect
+        :rtype: ExcludableItems
+        """
+        if self.include_entry_count() == 0:
+            return self
+
+        excludable = ExcludableItems.from_excludable(self)
+
+        for path in select_related:
+            parts = tuple(path.split("__"))
+            # Snapshot which prefixes carry a fields() reference before any
+            # exclusions are added below - the exclude additions would
+            # otherwise show up as "referenced" on the next iteration.
+            referenced = [
+                excludable._referenced_at(source_model, parts[: d + 1])
+                for d in range(len(parts))
+            ]
+            # Walk deepest-first so kept_deeper accumulates inward. Each
+            # segment still needs its own exclude when not kept, because
+            # ReverseAliasResolver only consults the immediate parent.
+            kept_deeper = False
+            for i in reversed(range(len(parts))):
+                kept_deeper = kept_deeper or referenced[i]
+                segment = parts[i]
+                parent_alias, parent_model = excludable._resolve_path(
+                    source_model, parts[:i]
+                )
+                parent_exc = excludable.get(parent_model, alias=parent_alias)
+                if parent_exc.is_explicitly_included(segment) or kept_deeper:
+                    continue
+                field = parent_model.ormar_config.model_fields[segment]
+                parent_exc.exclude.add(segment)
+                if field.is_multi:
+                    parent_exc.exclude.add(field.through.get_name())
+
+        return excludable
+
     def validate_flatten_vs_excludable(self, source_model: type["Model"]) -> None:
         """
         Ensure no flattened relation has sub-field include/exclude on its target.
@@ -635,11 +803,7 @@ class ExcludableItems:
                 source_model=source_model,
                 related_parts=list(parts),
             )
-            child_key = (
-                f"{table_prefix + '_' if table_prefix else ''}"
-                f"{target_model.get_name(lower=True)}"
-            )
-            child = self.items.get(child_key)
+            child = self.items.get(self._make_key(target_model, table_prefix))
             if not child:
                 continue
             conflicts = (child.include | child.exclude) - {...}

--- a/ormar/queryset/queryset.py
+++ b/ormar/queryset/queryset.py
@@ -694,14 +694,23 @@ class QuerySet(Generic[T]):
             return await self.fields(columns=fields).values(
                 _as_dict=_as_dict, _flatten=_flatten, exclude_through=exclude_through
             )
-        expr = self.build_select_expression()
+        excludable = self._excludable.with_projection_exclusions(
+            source_model=self.model,
+            select_related=self._select_related,
+        )
+        projected = (
+            self
+            if excludable is self._excludable
+            else self.rebuild_self(excludable=excludable)
+        )
+        expr = projected.build_select_expression()
         async with self.model_config.database.get_query_executor() as executor:
             rows = await executor.fetch_all(expr)
         if not rows:
             return []
         alias_resolver = ReverseAliasResolver(
             select_related=self._select_related,
-            excludable=self._excludable,
+            excludable=excludable,
             model_cls=self.model_cls,  # type: ignore
             exclude_through=exclude_through,
         )

--- a/tests/test_queries/test_values_and_values_list.py
+++ b/tests/test_queries/test_values_and_values_list.py
@@ -361,14 +361,7 @@ async def test_querysetproxy_values():
             .fields({"name": ..., "categories": {"name"}})
             .values(exclude_through=True)
         )
-        assert user == [
-            {
-                "name": "Anonymous",
-                "roles__id": 1,
-                "roles__name": "admin",
-                "categories__name": "News",
-            }
-        ]
+        assert user == [{"name": "Anonymous", "categories__name": "News"}]
 
         user = (
             await role.users.filter(name="Anonymous")
@@ -397,7 +390,7 @@ async def test_querysetproxy_values_list():
             .fields({"name": ..., "categories": {"name"}})
             .values_list(exclude_through=True)
         )
-        assert user == [("Anonymous", "News", 1, "admin")]
+        assert user == [("Anonymous", "News")]
 
         user = (
             await role.users.filter(name="Anonymous")
@@ -416,3 +409,142 @@ async def test_querysetproxy_values_list():
             .values_list(exclude_through=True, flatten=True)
         )
         assert user == ["Anonymous"]
+
+
+@pytest.mark.asyncio
+async def test_filter_related_does_not_leak_columns_in_values_list():
+    async with base_ormar_config.database:
+        posts = await Post.objects.filter(category__id=1).fields(["name"]).values_list()
+        assert posts == [
+            ("Ormar strikes again!",),
+            ("Why don't you use ormar yet?",),
+            ("Check this out, ormar now for free",),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_values_list_fields_kwarg_does_not_leak_related_columns():
+    async with base_ormar_config.database:
+        posts = await Post.objects.filter(category__id=1).values_list(fields=["name"])
+        assert posts == [
+            ("Ormar strikes again!",),
+            ("Why don't you use ormar yet?",),
+            ("Check this out, ormar now for free",),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_filter_related_does_not_leak_columns_in_values():
+    async with base_ormar_config.database:
+        posts = await Post.objects.filter(category__id=1).fields(["name"]).values()
+        assert posts == [
+            {"name": "Ormar strikes again!"},
+            {"name": "Why don't you use ormar yet?"},
+            {"name": "Check this out, ormar now for free"},
+        ]
+
+
+@pytest.mark.asyncio
+async def test_explicit_select_related_with_only_main_fields_excludes_related():
+    async with base_ormar_config.database:
+        posts = await Post.objects.select_related("category").fields(["name"]).values()
+        assert posts == [
+            {"name": "Ormar strikes again!"},
+            {"name": "Why don't you use ormar yet?"},
+            {"name": "Check this out, ormar now for free"},
+        ]
+
+
+@pytest.mark.asyncio
+async def test_nested_fields_keep_referenced_relation():
+    async with base_ormar_config.database:
+        posts = await (
+            Post.objects.select_related("category")
+            .fields(["name", "category__name"])
+            .values()
+        )
+        assert posts == [
+            {"name": "Ormar strikes again!", "category__name": "News"},
+            {"name": "Why don't you use ormar yet?", "category__name": "News"},
+            {"name": "Check this out, ormar now for free", "category__name": "News"},
+        ]
+
+
+@pytest.mark.asyncio
+async def test_m2m_relation_and_through_excluded_when_only_main_fields():
+    async with base_ormar_config.database:
+        roles = await (
+            Role.objects.select_related("users__categories").fields(["name"]).values()
+        )
+        assert roles == [{"name": "admin"}, {"name": "editor"}]
+
+
+@pytest.mark.asyncio
+async def test_relation_name_in_fields_keeps_relation_columns():
+    async with base_ormar_config.database:
+        posts = await (
+            Post.objects.select_related("category")
+            .fields({"name", "category"})
+            .values()
+        )
+        assert posts == [
+            {
+                "name": "Ormar strikes again!",
+                "category": 1,
+                "category__id": 1,
+                "category__name": "News",
+                "category__sort_order": 0,
+                "category__created_by": 1,
+            },
+            {
+                "name": "Why don't you use ormar yet?",
+                "category": 1,
+                "category__id": 1,
+                "category__name": "News",
+                "category__sort_order": 0,
+                "category__created_by": 1,
+            },
+            {
+                "name": "Check this out, ormar now for free",
+                "category": 1,
+                "category__id": 1,
+                "category__name": "News",
+                "category__sort_order": 0,
+                "category__created_by": 1,
+            },
+        ]
+
+
+@pytest.mark.asyncio
+async def test_filter_related_without_fields_keeps_all_columns():
+    async with base_ormar_config.database:
+        posts = await Post.objects.filter(category__id=1).values()
+        assert posts == [
+            {
+                "id": 1,
+                "name": "Ormar strikes again!",
+                "category": 1,
+                "category__id": 1,
+                "category__name": "News",
+                "category__sort_order": 0,
+                "category__created_by": 1,
+            },
+            {
+                "id": 2,
+                "name": "Why don't you use ormar yet?",
+                "category": 1,
+                "category__id": 1,
+                "category__name": "News",
+                "category__sort_order": 0,
+                "category__created_by": 1,
+            },
+            {
+                "id": 3,
+                "name": "Check this out, ormar now for free",
+                "category": 1,
+                "category__id": 1,
+                "category__name": "News",
+                "category__sort_order": 0,
+                "category__created_by": 1,
+            },
+        ]


### PR DESCRIPTION
Fixes #800.

`values()` / `values_list()` were leaking columns of related models that got pulled into the query by a filter (e.g. `filter(project__id=...)`) or a bare `select_related()` but were never named in `fields()`. The flat-projection result included every column of the joined model on top of what the caller actually requested.

The fix adds `ExcludableItems.with_projection_exclusions(source_model, select_related)`, called from `QuerySet.values()`. When `fields()` was used, it walks each select_related path and adds an implicit exclude for any segment (and its m2m through model) the user never referenced. Regular ORM-load queries (`get`, `all`, etc.) are unchanged - they still load all columns of unmentioned related models so Pydantic construction does not lose mandatory fields.