### PR TITLE
Fix cartesian product when filtering on two FKs to the same target

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Unreleased
+## 0.26.0
 
 ### ✨ Features
 
@@ -11,6 +11,18 @@
 
 ### 🐛 Fixes
 
+* Fix an unexpected cartesian product (cross join) when filtering on two
+  foreign keys that reach the same target table through the same relation
+  (e.g. `a_port__switch__name` and `z_port__switch__name`). The filter now
+  resolves complex join aliases in the same depth-first order as the join
+  builder, and ignores complex aliases left in the globally shared alias
+  manager by earlier queries, so a repeated query is no longer corrupted.
+  [#1706](https://github.com/collerek/ormar/issues/1706)
+* Require [`ormar-utils`](https://pypi.org/project/ormar-utils/) `>=0.2.0`,
+  which ships CPython stable-ABI (`abi3`) wheels. A single wheel now works on
+  Python 3.10+ — including 3.14 and future releases — so installing ormar no
+  longer fails for lack of a matching `ormar-utils` wheel on a new Python.
+  [#1702](https://github.com/collerek/ormar/issues/1702)
 * Fix race in `get_or_create` (and the m2m / reverse-fk variant) where
   concurrent callers leaked `IntegrityError`. [#1016](https://github.com/collerek/ormar/issues/1016)
 * Fix `update_or_create` raising `NoMatch` instead of creating when called

--- a/ormar/models/helpers/models.py
+++ b/ormar/models/helpers/models.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, ForwardRef
+from typing import TYPE_CHECKING, Any, ForwardRef
 
 import ormar_rust_utils
 import pydantic
@@ -124,6 +124,38 @@ def group_related_list(list_: list) -> dict:
     :rtype: dict[str, list]
     """
     return ormar_rust_utils.group_related_list(list_)
+
+
+def ordered_join_paths(related_tree: Any, prefix: str = "") -> list[str]:
+    """
+    Flattens a grouped relation tree (as produced by :func:`group_related_list`)
+    into the depth-first order in which the join builder walks the relations, with
+    shared prefixes visited only once.
+
+    Sample: {'people': {'houses': [], 'cars': ['models', 'colors']}}
+    will become:
+    ["people", "people__houses", "people__cars", "people__cars__models",
+    "people__cars__colors"]
+
+    :param related_tree: grouped relation tree (nested dict or list of leaf names)
+    :type related_tree: Any
+    :param prefix: relation path accumulated from the parent levels
+    :type prefix: str
+    :return: depth-first ordered list of relation paths
+    :rtype: list[str]
+    """
+    items = (
+        related_tree.items()
+        if isinstance(related_tree, dict)
+        else [(name, None) for name in related_tree]
+    )
+    paths: list[str] = []
+    for name, subtree in items:
+        path = f"{prefix}__{name}" if prefix else name
+        paths.append(path)
+        if subtree:
+            paths.extend(ordered_join_paths(subtree, path))
+    return paths
 
 
 def config_field_not_set(model: type["Model"], field_name: str) -> bool:

--- a/ormar/queryset/clause.py
+++ b/ormar/queryset/clause.py
@@ -1,4 +1,3 @@
-import itertools
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Generator, Optional, Union
@@ -7,6 +6,7 @@ import sqlalchemy
 from sqlalchemy import ColumnElement
 
 import ormar  # noqa I100
+from ormar.models.helpers.models import group_related_list, ordered_join_paths
 from ormar.queryset.actions.filter_action import FilterAction
 from ormar.queryset.utils import get_relationship_alias_model_and_str
 
@@ -195,6 +195,7 @@ class QueryClause:
 
         self.model_cls = model_cls
         self.table = self.model_cls.ormar_config.table
+        self._complex_dup_keys: set[str] = set()
 
     def prepare_filter(  # noqa: A003
         self, _own_only: bool = False, **kwargs: Any
@@ -263,30 +264,41 @@ class QueryClause:
         Checks if duplicate aliases are presented which can happen in self relation
         or when two joins end with the same pair of models.
 
-        If there are duplicates, the all duplicated joins are registered as source
-        model and whole relation key (not just last relation name).
+        Mirrors the join builder (:meth:`ormar.queryset.join.SqlJoin._forward_join`):
+        relation paths are walked in the same depth-first order the join uses, the
+        first path to reach a given basic alias keeps it, and every later path that
+        would reuse the same alias is registered as a complex duplicate keyed on the
+        whole relation string (not just the last relation name).
+
+        The keys registered for *this* query are stored on
+        :attr:`_complex_dup_keys` so that :meth:`_verify_prefix_and_switch` only
+        reroutes filters that are genuinely duplicated here, ignoring complex
+        aliases that linger in the globally shared alias manager from earlier
+        queries.
 
         :param select_related: list of relation strings
         :type select_related: list[str]
         :return: None
         :rtype: None
         """
-        prefixes = self._parse_related_prefixes(select_related=select_related)
-
         manager = self.model_cls.ormar_config.alias_manager
-        filtered_prefixes = sorted(prefixes, key=lambda x: x.table_prefix)
-        grouped = itertools.groupby(filtered_prefixes, key=lambda x: x.table_prefix)
-        for _, group in grouped:
-            sorted_group = sorted(
-                group, key=lambda x: len(x.relation_str), reverse=True
-            )
-            for prefix in sorted_group[:-1]:
+        self._complex_dup_keys = set()
+        seen_prefixes: set[str] = set()
+        for prefix in self._parse_related_prefixes(select_related=select_related):
+            if prefix.table_prefix in seen_prefixes:
+                self._complex_dup_keys.add(prefix.alias_key)
                 if prefix.alias_key not in manager:
                     manager.add_alias(alias_key=prefix.alias_key)
+            else:
+                seen_prefixes.add(prefix.table_prefix)
 
     def _parse_related_prefixes(self, select_related: list[str]) -> list[Prefix]:
         """
         Walks all relation strings and parses the target models and prefixes.
+
+        Relation strings are expanded into the depth-first order of joined tables
+        (shared prefixes visited once) so the duplicate detection matches the join
+        builder exactly.
 
         :param select_related: list of relation strings
         :type select_related: list[str]
@@ -294,7 +306,7 @@ class QueryClause:
         :rtype: list[Prefix]
         """
         prefixes: list[Prefix] = []
-        for related in select_related:
+        for related in ordered_join_paths(group_related_list(select_related)):
             prefix = Prefix(
                 self.model_cls,
                 *get_relationship_alias_model_and_str(
@@ -327,11 +339,19 @@ class QueryClause:
 
     def _verify_prefix_and_switch(self, action: "FilterAction") -> None:
         """
-        Helper to switch prefix to complex relation one if required
+        Helper to switch prefix to complex relation one if required.
+
+        Only reroutes filters whose relation string is a complex duplicate
+        registered for this query (see :meth:`_register_complex_duplicates`), so a
+        complex alias left in the shared alias manager by an earlier query cannot
+        hijack a filter that is not duplicated here.
+
         :param action: action to switch prefix in
         :type action: ormar.queryset.actions.filter_action.FilterAction
         """
         manager = self.model_cls.ormar_config.alias_manager
-        new_alias = manager.resolve_relation_alias(self.model_cls, action.related_str)
-        if "__" in action.related_str and new_alias:
-            action.table_prefix = new_alias
+        alias_key = f"{self.model_cls.get_name()}_{action.related_str}"
+        if "__" in action.related_str and alias_key in self._complex_dup_keys:
+            action.table_prefix = manager.resolve_relation_alias(
+                self.model_cls, action.related_str
+            )

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,7 +7,7 @@ description = "MySQL driver for asyncio."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"mysql\""
+markers = "extra == \"mysql\" or extra == \"all\""
 files = [
     {file = "aiomysql-0.3.2-py3-none-any.whl", hash = "sha256:c82c5ba04137d7afd5c693a258bea8ead2aad77101668044143a991e04632eb2"},
     {file = "aiomysql-0.3.2.tar.gz", hash = "sha256:72d15ef5cfc34c03468eb41e1b90adb9fd9347b0b589114bd23ead569a02ac1a"},
@@ -47,7 +47,7 @@ description = "asyncio bridge to the standard sqlite3 module"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"sqlite\""
+markers = "extra == \"sqlite\" or extra == \"all\""
 files = [
     {file = "aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb"},
     {file = "aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650"},
@@ -167,7 +167,7 @@ description = "Timeout context manager for asyncio programs"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"aiopg\" or extra == \"all\" or (extra == \"all\" or extra == \"postgres\" or extra == \"postgresql\" or extra == \"aiopg\") and python_version < \"3.11.0\""
+markers = "extra == \"aiopg\" or extra == \"all\" or (extra == \"postgresql\" or extra == \"postgres\" or extra == \"all\" or extra == \"aiopg\") and python_version < \"3.11.0\""
 files = [
     {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
     {file = "async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"},
@@ -180,7 +180,7 @@ description = "An asyncio PostgreSQL driver"
 optional = true
 python-versions = ">=3.9.0"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"postgres\" or extra == \"postgresql\""
+markers = "extra == \"postgresql\" or extra == \"postgres\" or extra == \"all\""
 files = [
     {file = "asyncpg-0.31.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:831712dd3cf117eec68575a9b50da711893fd63ebe277fc155ecae1c6c9f0f61"},
     {file = "asyncpg-0.31.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0b17c89312c2f4ccea222a3a6571f7df65d4ba2c0e803339bfc7bed46a96d3be"},
@@ -314,7 +314,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"crypto\") and platform_python_implementation != \"PyPy\""
+markers = "(extra == \"crypto\" or extra == \"all\") and platform_python_implementation != \"PyPy\""
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -690,7 +690,7 @@ description = "cryptography is a package which provides cryptographic recipes an
 optional = true
 python-versions = "!=3.9.0,!=3.9.1,>=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"crypto\""
+markers = "extra == \"crypto\" or extra == \"all\""
 files = [
     {file = "cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6"},
     {file = "cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c"},
@@ -1795,32 +1795,18 @@ files = [
 
 [[package]]
 name = "ormar-utils"
-version = "0.1.1"
+version = "0.2.0"
 description = "Rust-accelerated utility functions for the ormar ORM"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "ormar_utils-0.1.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:e1abb5494942a937c317aac909979c422aac745c58121042216ba4163f22ef47"},
-    {file = "ormar_utils-0.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1f80e577d840ae0f2e6455b84e6e6e6351a776a514af8b6ff1f809f24a71f432"},
-    {file = "ormar_utils-0.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:522f6fe1f68f4cd90a77a0851e2bcffbd7d473cb5eb492f53a79ecd249b4a95a"},
-    {file = "ormar_utils-0.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77bcfffbef6f81a61192290834b2b80fbfeaa64242a8fbcdefe00051b9f5e70d"},
-    {file = "ormar_utils-0.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:3e316b727853f0d722663e8af74aca8f9572f8340a76694ebd8a377fc6d6bfbe"},
-    {file = "ormar_utils-0.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a5468770de8d01b36702fe96aa553efb30da46313304b97d113871519d4fec5b"},
-    {file = "ormar_utils-0.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:047f5e113e3adb68e4dc7d3915d999ed44a3e6914a5a0a8162cfc0f1bcc24a24"},
-    {file = "ormar_utils-0.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b510c48557a1809e53a851b7acee4bac8fb7adac12ce738d3911b6ed85dc7bb"},
-    {file = "ormar_utils-0.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:530c46dcfcfb26067abd6e148b2c2337cfcefa1945cbffcae8a8b73ee816a101"},
-    {file = "ormar_utils-0.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:d1cec4877a86d7f654d795f3f49bb4f8d81843032dc05f5a741ce471672f5c5d"},
-    {file = "ormar_utils-0.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:85e83277179776bd8d4915ce4a5e30e68054be22f3d4e4428e2f0a5515b113e1"},
-    {file = "ormar_utils-0.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2736d32eeeb403f7883a4ffcc67b716e492ef38940d9ca42b9be7f1c958a458a"},
-    {file = "ormar_utils-0.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b69e0a1903c1eb8c63f284eec96aa550e44a417d79e673254b83d73b290c4c60"},
-    {file = "ormar_utils-0.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da04622f42cc33dd88a94f21dda0f04ff7ff0773e3e3a176ef8d9bad5e60a1c1"},
-    {file = "ormar_utils-0.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:a803c9f3b314eb54220bace76f7c49d091f305bba2fa591c19eead33ef5b1741"},
-    {file = "ormar_utils-0.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f8635e83857b85e2521db8cf55c1c659169912713632b9bc8f7cb617df3235df"},
-    {file = "ormar_utils-0.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4892b801969cbb402748a12920b8c285707fdb2540fe423b6c96bcbd6004aa98"},
-    {file = "ormar_utils-0.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fae770725f88168f8dcecfafaca27375397a62a97776c2818b5a99c6d4baeb8d"},
-    {file = "ormar_utils-0.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5bd489da692e9b94f27a577acf30465b30e94932f01f2745830cb94b1b413ce"},
-    {file = "ormar_utils-0.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:405ed56e66cff421f293509d3e0a86af7da88663420a2d3ea5719e755421bb2a"},
+    {file = "ormar_utils-0.2.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e164f5d3636a660cec8df91cc1a0e2159bbb429f55d990272c096b1eef9d6c59"},
+    {file = "ormar_utils-0.2.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:40f3d45737017309cea3c62569394cc56e4c1558f9926f1dded580eeb6f730bb"},
+    {file = "ormar_utils-0.2.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f93299eda3e3a72fdbf5ff4ce8c82ff801247bba616debc52dbb48915480d3ce"},
+    {file = "ormar_utils-0.2.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:55c7ec5e002b0cc5394830c2b8c109a5b492d518fc95367dcf6b1da57c8510e4"},
+    {file = "ormar_utils-0.2.0-cp310-abi3-win_amd64.whl", hash = "sha256:122c7dd9f2eb52342be4862beda0737f98e7813c01751793f0fa53715f5b3959"},
+    {file = "ormar_utils-0.2.0.tar.gz", hash = "sha256:e2bf1ff71fbb820cac192b33583d58fac29e838a79804995336ef2bee02cc9ae"},
 ]
 
 [[package]]
@@ -1957,7 +1943,7 @@ description = "psycopg2 - Python-PostgreSQL Database Adapter"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"aiopg\" or extra == \"all\" or extra == \"postgres\" or extra == \"postgresql\""
+markers = "extra == \"aiopg\" or extra == \"all\" or extra == \"postgresql\" or extra == \"postgres\""
 files = [
     {file = "psycopg2_binary-2.9.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b818ceff717f98851a64bffd4c5eb5b3059ae280276dcecc52ac658dcf006a4"},
     {file = "psycopg2_binary-2.9.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d2fa0d7caca8635c56e373055094eeda3208d901d55dd0ff5abc1d4e47f82b56"},
@@ -2047,7 +2033,7 @@ description = "C parser in Python"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"crypto\") and platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
+markers = "(extra == \"crypto\" or extra == \"all\") and platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
@@ -2277,7 +2263,7 @@ description = "Pure Python MySQL Driver"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"mysql\""
+markers = "extra == \"mysql\" or extra == \"all\""
 files = [
     {file = "pymysql-1.2.0-py3-none-any.whl", hash = "sha256:62169ce6d5510f08e140c5e7990ee884a9764024e4a9a27b2cc11f1099322ae0"},
     {file = "pymysql-1.2.0.tar.gz", hash = "sha256:6c7b17ca686988104d7426c27895b455cdeea3e9d3ceb1270f0c3704fead8c33"},
@@ -3138,4 +3124,4 @@ sqlite = ["aiosqlite"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.0"
-content-hash = "31f5c84a4759a7f246acaff94513208abe99933f9eb843b27149be8434f710cc"
+content-hash = "ee20c99bf036c0659e078adcfc74a957a5569edf0f3abf1c6c60e46e4530d804"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ormar"
 
 [tool.poetry]
 name = "ormar"
-version = "0.25.0"
+version = "0.26.0"
 description = "An async ORM with fastapi in mind and pydantic validation."
 authors = ["Radosław Drążkiewicz <collerek@gmail.com>"]
 license = "MIT"
@@ -60,7 +60,7 @@ asyncpg = { version = ">=0.28,<0.32", optional = true }
 psycopg2-binary = { version = "^2.9.1", optional = true }
 mysqlclient = { version = "^2.1.0", optional = true }
 PyMySQL = { version = "^1.1.0", optional = true }
-ormar-utils = ">=0.1.1"
+ormar-utils = ">=0.2.0"
 orjson = ">=3.6.4"
 
 

--- a/tests/test_queries/test_multi_fk_to_same_target_filter.py
+++ b/tests/test_queries/test_multi_fk_to_same_target_filter.py
@@ -1,0 +1,91 @@
+import pytest
+
+import ormar
+from tests.lifespan import init_tests
+from tests.settings import create_config
+
+base_ormar_config = create_config()
+
+
+class Switch(ormar.Model):
+    ormar_config = base_ormar_config.copy(tablename="switch")
+
+    id: int = ormar.Integer(primary_key=True)
+    name: str = ormar.String(max_length=100)
+
+
+class Port(ormar.Model):
+    ormar_config = base_ormar_config.copy(tablename="port")
+
+    id: int = ormar.Integer(primary_key=True)
+    switch: Switch = ormar.ForeignKey(Switch)
+
+
+class Link(ormar.Model):
+    ormar_config = base_ormar_config.copy(tablename="link")
+
+    id: int = ormar.Integer(primary_key=True)
+    a_port: Port = ormar.ForeignKey(Port, related_name="a_links")
+    z_port: Port = ormar.ForeignKey(Port, related_name="z_links")
+
+
+create_test_database = init_tests(base_ormar_config)
+
+
+def from_clause(expression) -> str:
+    """Extracts the FROM ... (up to WHERE) part of the compiled SQL."""
+    sql = str(expression.compile(compile_kwargs={"literal_binds": True}))
+    return sql.split("FROM", 1)[1].split("WHERE")[0]
+
+
+def has_cartesian_product(queryset) -> bool:
+    """A comma in the FROM clause means an unjoined (cross-product) table."""
+    return "," in from_clause(queryset.build_select_expression())
+
+
+@pytest.mark.asyncio
+async def test_filter_on_two_fks_to_same_target_has_no_cartesian_product():
+    async with base_ormar_config.database:
+        queryset = Link.objects.filter(
+            a_port__switch__name__in=["a0", "a1"],
+            z_port__switch__name__in=["z0", "z1"],
+        )
+        assert not has_cartesian_product(queryset)
+
+
+@pytest.mark.asyncio
+async def test_repeated_query_not_corrupted_by_alias_manager_state():
+    async with base_ormar_config.database:
+        # Build the two-sided filter first; in the buggy version this pollutes
+        # the global alias manager and corrupts the next, simpler query.
+        Link.objects.filter(
+            a_port__switch__name__in=["a0", "a1"],
+            z_port__switch__name__in=["z0", "z1"],
+        ).build_select_expression()
+
+        queryset = Link.objects.filter(
+            a_port__switch__in=[1, 2],
+            z_port__switch__name__in=["z0", "z1"],
+        )
+        assert not has_cartesian_product(queryset)
+
+
+@pytest.mark.asyncio
+async def test_each_filter_targets_its_own_branch():
+    async with base_ormar_config.database:
+        switch_a = await Switch(name="switch_a").save()
+        switch_z = await Switch(name="switch_z").save()
+        port_a = await Port(switch=switch_a).save()
+        port_z = await Port(switch=switch_z).save()
+        other = await Port(switch=switch_z).save()
+
+        wanted = await Link(a_port=port_a, z_port=port_z).save()
+        await Link(a_port=other, z_port=port_z).save()
+
+        result = await Link.objects.filter(
+            a_port__switch__name="switch_a",
+            z_port__switch__name="switch_z",
+        ).all()
+
+        assert len(result) == 1
+        assert result[0].id == wanted.id


### PR DESCRIPTION
When two relation chains converge on the same target via the same final relation (e.g. `a_port__switch` and `z_port__switch`), the filter side chose which path got a complex alias by `relation_str` length while the join builder uses depth-first order — so equal-length siblings were aliased inconsistently and the WHERE clause referenced a table the join never created, producing a cartesian product. Complex aliases also linger in the globally shared alias manager, letting a later simpler query pick one up.

The filter now walks relation paths in the same depth-first order as the join (first occurrence keeps the basic alias, later ones go complex) and only reroutes filters whose key is a duplicate registered for the current query. Added regression tests covering the no-cartesian case, cross-query state isolation, and correct row results.

Closes #1706