### PR TITLE
Bump MySQL 5.7 to 8.0

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_USER: username
           MYSQL_PASSWORD: password

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,7 +7,7 @@ description = "MySQL driver for asyncio."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"mysql\""
+markers = "extra == \"mysql\" or extra == \"all\""
 files = [
     {file = "aiomysql-0.3.2-py3-none-any.whl", hash = "sha256:c82c5ba04137d7afd5c693a258bea8ead2aad77101668044143a991e04632eb2"},
     {file = "aiomysql-0.3.2.tar.gz", hash = "sha256:72d15ef5cfc34c03468eb41e1b90adb9fd9347b0b589114bd23ead569a02ac1a"},
@@ -47,7 +47,7 @@ description = "asyncio bridge to the standard sqlite3 module"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"sqlite\""
+markers = "extra == \"sqlite\" or extra == \"all\""
 files = [
     {file = "aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb"},
     {file = "aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650"},
@@ -170,7 +170,7 @@ description = "Timeout context manager for asyncio programs"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"aiopg\" or extra == \"all\" or (extra == \"all\" or extra == \"postgres\" or extra == \"postgresql\" or extra == \"aiopg\") and python_version < \"3.11.0\""
+markers = "extra == \"aiopg\" or extra == \"all\" or (extra == \"postgresql\" or extra == \"postgres\" or extra == \"all\" or extra == \"aiopg\") and python_version < \"3.11.0\""
 files = [
     {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
     {file = "async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"},
@@ -183,7 +183,7 @@ description = "An asyncio PostgreSQL driver"
 optional = true
 python-versions = ">=3.9.0"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"postgres\" or extra == \"postgresql\""
+markers = "extra == \"postgresql\" or extra == \"postgres\" or extra == \"all\""
 files = [
     {file = "asyncpg-0.31.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:831712dd3cf117eec68575a9b50da711893fd63ebe277fc155ecae1c6c9f0f61"},
     {file = "asyncpg-0.31.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0b17c89312c2f4ccea222a3a6571f7df65d4ba2c0e803339bfc7bed46a96d3be"},
@@ -317,7 +317,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"crypto\") and platform_python_implementation != \"PyPy\""
+markers = "(extra == \"crypto\" or extra == \"all\" or extra == \"mysql\") and platform_python_implementation != \"PyPy\""
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -693,7 +693,7 @@ description = "cryptography is a package which provides cryptographic recipes an
 optional = true
 python-versions = "!=3.9.0,!=3.9.1,>=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"crypto\""
+markers = "extra == \"crypto\" or extra == \"all\" or extra == \"mysql\""
 files = [
     {file = "cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db"},
     {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db"},
@@ -1946,7 +1946,7 @@ description = "psycopg2 - Python-PostgreSQL Database Adapter"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"aiopg\" or extra == \"all\" or extra == \"postgres\" or extra == \"postgresql\""
+markers = "extra == \"aiopg\" or extra == \"all\" or extra == \"postgresql\" or extra == \"postgres\""
 files = [
     {file = "psycopg2_binary-2.9.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b818ceff717f98851a64bffd4c5eb5b3059ae280276dcecc52ac658dcf006a4"},
     {file = "psycopg2_binary-2.9.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d2fa0d7caca8635c56e373055094eeda3208d901d55dd0ff5abc1d4e47f82b56"},
@@ -2036,7 +2036,7 @@ description = "C parser in Python"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"crypto\") and platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
+markers = "(extra == \"crypto\" or extra == \"all\" or extra == \"mysql\") and platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
@@ -2266,11 +2266,14 @@ description = "Pure Python MySQL Driver"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"mysql\""
+markers = "extra == \"mysql\" or extra == \"all\""
 files = [
     {file = "pymysql-1.2.0-py3-none-any.whl", hash = "sha256:62169ce6d5510f08e140c5e7990ee884a9764024e4a9a27b2cc11f1099322ae0"},
     {file = "pymysql-1.2.0.tar.gz", hash = "sha256:6c7b17ca686988104d7426c27895b455cdeea3e9d3ceb1270f0c3704fead8c33"},
 ]
+
+[package.dependencies]
+cryptography = {version = ">=46.0.7", optional = true, markers = "extra == \"rsa\""}
 
 [package.extras]
 ed25519 = ["PyNaCl (>=1.6.2)"]
@@ -3127,4 +3130,4 @@ sqlite = ["aiosqlite"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.0"
-content-hash = "3de9af4148b9584cf35cdb309af40e4a37b2f45cfe8618670f46226d29d898d5"
+content-hash = "63ebd1b778c43db999130bddf661e93d29e8b036e2507eada6861d47577ef8ba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ asyncpg = { version = ">=0.28,<0.32", optional = true }
 # Sync database drivers for standard tooling around setup/teardown/migrations.
 psycopg2-binary = { version = "^2.9.1", optional = true }
 mysqlclient = { version = "^2.1.0", optional = true }
-PyMySQL = { version = "^1.1.0", optional = true }
+PyMySQL = { version = "^1.1.0", extras = ["rsa"], optional = true }
 ormar-utils = ">=0.2.0"
 orjson = ">=3.6.4"
 

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - 5432:5432
 
   mysql:
-    image: mysql:5.7
+    image: mysql:8.0
     environment:
       MYSQL_USER: username
       MYSQL_PASSWORD: password

--- a/tests/test_relations/test_select_related_with_m2m_and_pk_name_set.py
+++ b/tests/test_relations/test_select_related_with_m2m_and_pk_name_set.py
@@ -16,7 +16,7 @@ base_ormar_config = create_config()
 class Role(ormar.Model):
     ormar_config = base_ormar_config.copy()
 
-    name: str = ormar.String(primary_key=True, max_length=1000)
+    name: str = ormar.String(primary_key=True, max_length=768)
     order: int = ormar.Integer(default=0, name="sort_order")
     description: str = ormar.Text()
 
@@ -24,7 +24,7 @@ class Role(ormar.Model):
 class Company(ormar.Model):
     ormar_config = base_ormar_config.copy()
 
-    name: str = ormar.String(primary_key=True, max_length=1000)
+    name: str = ormar.String(primary_key=True, max_length=768)
 
 
 class UserRoleCompany(ormar.Model):
@@ -34,7 +34,7 @@ class UserRoleCompany(ormar.Model):
 class User(ormar.Model):
     ormar_config = base_ormar_config.copy()
 
-    registrationnumber: str = ormar.String(primary_key=True, max_length=1000)
+    registrationnumber: str = ormar.String(primary_key=True, max_length=768)
     company: Company = ormar.ForeignKey(Company)
     company2: Company = ormar.ForeignKey(Company, related_name="secondary_users")
     name: str = ormar.Text()


### PR DESCRIPTION
Upgrades MySQL from EOL 5.7 to 8.0 in CI and local docker-compose. Adds PyMySQL's `rsa` extra so `ormar[mysql]` pulls `cryptography` and connects to MySQL 8's default `caching_sha2_password` auth out of the box. Shortens three `VARCHAR(1000)` primary keys in one test to 768 to fit MySQL 8's `utf8mb4` 3072-byte single-column index limit.

Prep for case-insensitive unique constraints (#615), which needs functional indexes (MySQL 8.0.13+).